### PR TITLE
Make Details more accessible

### DIFF
--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/form-details/form-details.twig
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/form-details/form-details.twig
@@ -11,9 +11,14 @@
   'tablet:text-base leading-6 text-forest-100 cursor-pointer'
 ]) %}
 
-<details{{ attributes }}>
+<details{{ attributes }}
+  aria-label="Toggle {{ title }} filters"
+  aria-controls="{{ attributes.storage['id']|render }}"
+  x-data="{ isOpen: false }"
+  x-bind:aria-expanded="isOpen ? 'true' : 'false'"
+  >
   {%- if title -%}
-    <summary{{ summary_attributes }}>
+    <summary{{ summary_attributes }} x-on:click="isOpen = !isOpen">
       <div class="flex">
         <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M12.5 16.1455C12.1875 16.1455 11.9792 16.0413 11.7708 15.833L6.5625 10.6247C6.14583 10.208 6.14583 9.58301 6.5625 9.16634C6.97917 8.74967 7.60417 8.74967 8.02083 9.16634L12.5 13.6455L16.9792 9.16634C17.3958 8.74967 18.0208 8.74967 18.4375 9.16634C18.8542 9.58301 18.8542 10.208 18.4375 10.6247L13.2292 15.833C13.0208 16.0413 12.8125 16.1455 12.5 16.1455Z" fill="#00594C"/>


### PR DESCRIPTION
# Notes

I didn't follow the recommendations here, I had another idea for a quick win. I used `aria-label`, `aria-controls` and `aria-expanded` to make the checkboxes more accessible.

If we're to follow the recommendations we lose the accordion functionality on these components. 