### PR TITLE
Fix gutter spacing in several components

### DIFF
--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/cta-banner/cta-banner.scss
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/cta-banner/cta-banner.scss
@@ -9,7 +9,7 @@
 
   &--left {
     .m-cta-banner__content {
-      @apply tablet:order-2 tablet:ml-4;
+      @apply tablet:order-2;
     }
     .m-cta-banner__media {
       @apply tablet:order-1;

--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/cta-banner/cta-banner.twig
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/cta-banner/cta-banner.twig
@@ -9,7 +9,7 @@
     {{ header }}
   </h2>
   {% endif %}
-  <div class="m-cta-banner__container tablet:flex tablet:gap-4">
+  <div class="m-cta-banner__container tablet:flex tablet:gap-6">
     <div class="m-cta-banner__content tablet:w-6/12 tablet:flex tablet:flex-col tablet:justify-between">
       {% if title %}
       <h2 class="m-cta-banner__title text-md leading-tight mb-4">{{ title }}</h2>

--- a/docroot/themes/custom/dhsc_theme/stories/03-organisms/card-collection/card-collection.twig
+++ b/docroot/themes/custom/dhsc_theme/stories/03-organisms/card-collection/card-collection.twig
@@ -7,7 +7,7 @@
       <h2 class="o-card_collection__title text-lg leading-tight font-bold mb-4">{{ title }}</h2>
     {% endif %}
     {% if items is not empty %}
-      <div class="o-card_collection__listing tablet:flex tablet:gap-4">
+      <div class="o-card_collection__listing tablet:flex tablet:gap-6">
         {% if items is iterable %}
           {% for key, item in items if key|first != '#' %}
             {{ item }}

--- a/docroot/themes/custom/dhsc_theme/stories/03-organisms/featured-items/featured-items.scss
+++ b/docroot/themes/custom/dhsc_theme/stories/03-organisms/featured-items/featured-items.scss
@@ -8,7 +8,7 @@
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         grid-template-rows: 1fr;
-        grid-column-gap: theme('spacing.4');
+        grid-column-gap: theme('spacing.6');
         grid-row-gap: 0px;
         > div:nth-child(1) {
           grid-area: 1 / 1 / 2 / 2;
@@ -26,7 +26,7 @@
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         grid-template-rows: repeat(2, 1fr);
-        grid-column-gap: theme('spacing.4');
+        grid-column-gap: theme('spacing.6');
         grid-row-gap: 0px;
         > div:nth-child(1) {
           grid-area: 1 / 1 / 3 / 2;
@@ -47,7 +47,7 @@
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         grid-template-rows: repeat(3, 1fr);
-        grid-column-gap: theme('spacing.4');
+        grid-column-gap: theme('spacing.6');
         grid-row-gap: 0px;
         > div:nth-child(1) {
           grid-area: 1 / 1 / 4 / 2;

--- a/docroot/themes/custom/dhsc_theme/stories/03-organisms/quick-links/quick-links.twig
+++ b/docroot/themes/custom/dhsc_theme/stories/03-organisms/quick-links/quick-links.twig
@@ -6,9 +6,9 @@
     {% if title %}
       <h2 class="o-quick-links__title text-lg leading-tight font-bold mb-4">{{ title }}</h2>
     {% endif %}
-    <div class="o-quick-links__content tablet:flex tablet:gap-4">
+    <div class="o-quick-links__content tablet:flex tablet:gap-6">
       {% if items_left is not empty %}
-        <div class="o-quick-links__column tablet:flex tablet:flex-col tablet:gap-4 flex-1">
+        <div class="o-quick-links__column tablet:flex tablet:flex-col tablet:gap-6 flex-1">
           {% if items_left is iterable %}
             {% for key, item in items_left if key|first != '#' %}
               {{ item }}

--- a/docroot/themes/custom/dhsc_theme/stories/03-organisms/topics/topics.twig
+++ b/docroot/themes/custom/dhsc_theme/stories/03-organisms/topics/topics.twig
@@ -7,7 +7,7 @@
       <h2 class="o-topics__title text-lg leading-tight font-bold mb-4">{{ title }}</h2>
     {% endif %}
     {% if items is not empty %}
-      <div class="o-topics__listing tablet:grid tablet:grid-cols-3 tablet:gap-4">
+      <div class="o-topics__listing tablet:grid tablet:grid-cols-3 tablet:gap-6">
         {% if items is iterable %}
           {% for key, item in items if key|first != '#' %}
             {{ item }}


### PR DESCRIPTION
Adjust gutter to 30px in cta banner, cards, featured items, quick links and topics.