### PR TITLE
Feature/supplier no match component preview

### DIFF
--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/tool-supplier/tool-supplier--nomatch.twig
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/tool-supplier/tool-supplier--nomatch.twig
@@ -16,18 +16,29 @@
   <div class="m-tool-supplier__content">
     <h4 class="text-base text-bold mb-2">{{ 'Criteria not met:'|t }}</h4>
     {% if answers is iterable %}
-      {% for key, value in answers %}
-        <div class="m-tool-supplier__section text-coolgrey text-xs mb-2">{{ key }}</div>
-        {% for answer in value %}
+      {% if preview_component %}
+        {% for answer in answers %}
+          <div class="m-tool-supplier__section text-coolgrey text-xs mb-2">{{ answer.section }}</div>
           <ul class="list-disc pl-4 mb-4">
-            <li>
-              <div class="m-tool-supplier__answer text-coolgrey text-xs">{{ answer }}</div>
-            </li>
+            {% for item in answer.answer %}
+              <li>
+                <div class="m-tool-supplier__answer text-coolgrey text-xs">{{ item }}</div>
+              </li>
+            {% endfor %}
           </ul>
         {% endfor %}
-      {% endfor %}
-    {% else %}
-      {{ answers }}
+      {% else %}
+        {# Drupal component rendering #}
+        {% for key, value in answers %}
+          <div class="m-tool-supplier__section text-coolgrey text-xs mb-2">{{ key }}</div>
+          {% for answer in value %}
+            <ul class="list-disc pl-4 mb-4">
+              <li>
+                <div class="m-tool-supplier__answer text-coolgrey text-xs">{{ answer }}</div>
+              </li>
+            </ul>
+          {% endfor %}
+        {% endfor %}
+      {% endif %}
     {% endif %}
   </div>
-</div>

--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/tool-supplier/tool-supplier.stories.js
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/tool-supplier/tool-supplier.stories.js
@@ -16,13 +16,14 @@ const toolSupplierMatchTemplate = ({ attributes, variant, title, url, content })
     content
   });
 
-const toolSupplierNoMatchTemplate = ({ attributes, variant, title, url, answers }) =>
+const toolSupplierNoMatchTemplate = ({ attributes, variant, title, url, answers, preview_component }) =>
   toolSupplierNoMatchTwig({
     attributes,
     variant,
     title,
     url,
     answers,
+    preview_component
   });
 
 export const toolSupplierMatch = toolSupplierMatchTemplate.bind({});
@@ -40,5 +41,19 @@ toolSupplierNoMatch.args = {
   variant: 'nomatch',
   title: "Microsoft",
   url: "https://www.digitalsocialcare.co.uk",
-  answers: ['Extra care services', 'Domiciliary care services']
+  preview_component: true,
+  answers: [
+    {
+      section: 'Section 1',
+      answer: [
+        'answer 1', 'answer 2', 'answer 3'
+      ]
+    },
+    {
+      section: 'Section 2',
+      answer: [
+        'answer 1', 'answer 2', 'answer 3'
+      ]
+    },
+  ]
 };


### PR DESCRIPTION
- Fixes component preview in SB
- Could not manipulate data in Drupal for format needed in SB so passed a 'preview_component' variable from the component into twig with conditional rendering for both SB and Drupal.