### PR TITLE
Feature/dhsc 155  self assessment tool a amends

### DIFF
--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.routing.yml
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.routing.yml
@@ -20,7 +20,7 @@ dhsc_result_viewer.result_summary_self_assessment:
   path: '/dhsc-results-list-self-assessment'
   defaults:
     _controller: '\Drupal\dhsc_result_viewer\Controller\ResultSummarySelfAssessmentController::build'
-    _title: 'Result Summary'
+    _title: 'Recommendations'
   requirements:
     _permission: 'access content'
   options:

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.services.yml
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.services.yml
@@ -5,3 +5,8 @@ services:
   dhsc_assured_solutions_result_viewer.service:
     class: Drupal\dhsc_result_viewer\AssuredSolutionsResultViewer
     arguments: ['@entity_type.manager', '@config.factory', '@tempstore.private']
+  dhsc_result_viewer.breadcrumb:
+    class: Drupal\dhsc_result_viewer\Breadcrumb\SelfAssessmentBreadcrumbBuilder
+    arguments: ['@string_translation']
+    tags:
+      - { name: breadcrumb_builder, priority: 1008}

--- a/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
@@ -8,7 +8,6 @@ use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
-use Drupal\Core\Url;
 use Drupal\webform\Entity\Webform;
 
 class SelfAssessmentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
@@ -52,7 +51,7 @@ class SelfAssessmentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       // Get the route name of the webform.
       $webformURL = $webform->toUrl();
 
-      $breadcrumb->addLink(Link::fromTextAndUrl($this->t('Self Assessment Tool'), $webformURL));
+      $breadcrumb->addLink(Link::fromTextAndUrl($this->t('Get started with digital'), $webformURL));
     }
 
     $breadcrumb->addLink(Link::createFromRoute($this->t('Recommendations'), '<none>'));

--- a/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\dhsc_result_viewer\Breadcrumb;
+
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Link;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\webform\Entity\Webform;
+
+class SelfAssessmentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Constructs the HelpBreadcrumbBuilder.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The translation service.
+   */
+  public function __construct(TranslationInterface $string_translation) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    // Check if the current route matches your custom page controller route.
+    return ($route_match->getRouteName() == 'dhsc_result_viewer.result_summary_self_assessment');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+
+    $breadcrumb->addCacheContexts(['url.path.parent']);
+    // Add the homepage link as the first item in the breadcrumb trail.
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
+
+    // Add Self assessment tool form to breadcrumb trail.
+    /** @var \Drupal\webform\Entity\Webform $webform */
+    $webform = Webform::load('self_assessment_tool');
+
+    // Check if the webform exists.
+    if ($webform && $webform->status()) {
+      // Get the route name of the webform.
+      $webformURL = $webform->toUrl();
+
+      $breadcrumb->addLink(Link::fromTextAndUrl($this->t('Self Assessment Tool'), $webformURL));
+    }
+
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Recommendations'), '<none>'));
+
+    return $breadcrumb;
+  }
+
+}

--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/back-link/back-link.scss
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/back-link/back-link.scss
@@ -8,6 +8,6 @@
   }
 
   &__label {
-    @apply text-base text-forest-100 ml-2;
+    @apply text-xs text-forest-100 ml-2;
   }
 }

--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/webform/webform.js
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/webform/webform.js
@@ -1,5 +1,25 @@
 // Only run Drupal code if Drupal is defined.
 if (typeof Drupal !== 'undefined') {
+
+  Drupal.behaviors.multi_step_webform_breadcrumbs = {
+    attach: function (context) {
+      // Find webform with class
+      const form = context.querySelector('form.m-webform__submission-form--hide-breadcrumbs');
+      // If exists
+      if (form) {
+        const step = form.querySelector('.webform-step-use-page-title');
+        // Check if on first step
+        if (step && step.dataset.webformKey === 'step_1') {
+          // If so hide back button
+          document.querySelector('.m-back-link').style.display = 'none'
+        } else {
+          // Else hide breadcrumbs
+          document.querySelector('.o-breadcrumb-region').style.display = 'none'
+        }
+      }
+    }
+  }
+
   Drupal.behaviors.multi_step_webform_meta_title = {
     attach: function (context) {
       // Find replacement title for webform page

--- a/docroot/themes/custom/dhsc_theme/stories/02-molecules/webform/webform.scss
+++ b/docroot/themes/custom/dhsc_theme/stories/02-molecules/webform/webform.scss
@@ -64,4 +64,7 @@
     }
   }
 
+  &--title-prefix {
+    @apply text-md text-coolgrey mb-1;
+  }
 }


### PR DESCRIPTION
### Deployment notes

- If you want to remove breadcrumbs from the form page you have to add the following class to the webform (form tag): `m-webform__submission-form--hide-breadcrumbs`
- the first wizard page of the webform must heave the following machine name `step_1`