### PR TITLE
feat : (DHSCSM-14) show most recent event first on events pages.

### DIFF
--- a/config/default/sync/views.view.content_listings.yml
+++ b/config/default/sync/views.view.content_listings.yml
@@ -526,7 +526,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: datetime
-          order: DESC
+          order: ASC
           expose:
             label: ''
             field_identifier: ''


### PR DESCRIPTION
Title and link fields for the latest news and latest events views have been added directly to the view templates. These values are unlikely to change for these components. It would involve a bigger piece of work to make these field-able for the view components and match existing styles for 'Featured items' and 'Cards. 