### PR TITLE
Task/jdla 32 implement coding standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ export-db:
 coding-standards:
 	docker run --rm -v `pwd`:/work skilldlabs/docker-phpcs-drupal phpcs --standard=Drupal,DrupalPractice docroot/themes/custom/ docroot/modules/custom/ --ignore="*/node_modules/*, themes/custom/dhsc_theme/stories, themes/custom/dhsc_theme/.storybook"
 
+coding-standards-fix:
+	docker run --rm -v `pwd`:/work skilldlabs/docker-phpcs-drupal phpcbf --standard=Drupal,DrupalPractice docroot/themes/custom/ docroot/modules/custom/ --ignore="*/node_modules/*, themes/custom/dhsc_theme/stories, themes/custom/dhsc_theme/.storybook"
+
 fe-watch:
 	npm run watch --prefix ${THEME_DIR}
 

--- a/docroot/modules/custom/dhsc_result_viewer/css/style.css
+++ b/docroot/modules/custom/dhsc_result_viewer/css/style.css
@@ -3,8 +3,7 @@ h3 {
   font-family: arial, helvetica, sans-serif;
 }
 
-.results
-h3,
+.results h3,
 h4,
 li,
 strong,

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
@@ -2,15 +2,11 @@
 
 /**
  * @file
+ * Module to create result pages.
  */
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-
-/**
- * @file
- * Module to create result pages.
- */
 
 /**
  * Implements hook_theme().
@@ -142,12 +138,8 @@ function dhsc_result_viewer_theme() {
 
 /**
  * Implements hook_form_alter().
- *
- * @param [type] $form
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- * @param [type] $form_id
  */
-function dhsc_result_viewer_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function dhsc_result_viewer_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   // Re-write submit label when re-submitting answers.
   $form_ids = [
     'webform_submission_assured_solutions_tool_edit_form',
@@ -162,7 +154,6 @@ function dhsc_result_viewer_form_alter(&$form, FormStateInterface $form_state, $
   ) {
     $form['actions']['submit']['#value'] = t('Continue');
   }
-
 }
 
 /**
@@ -170,29 +161,33 @@ function dhsc_result_viewer_form_alter(&$form, FormStateInterface $form_state, $
  */
 function dhsc_result_viewer_mail($key, &$message, $params) {
   $message['from'] = $params['headers']['From'] ?? NULL;
-  // Strip newline characters from email subjects.
-  $message['subject'] = isset($params['subject']) ? str_replace(["\r\n", "\r", "\n"], ' ', $params['subject']) : NULL;
-  $message['body'] = $params['body'];
 
+  // Strip newline characters from email subjects.
+  $message['subject'] = isset($params['subject'])
+    ? str_replace(["\r\n", "\r", "\n"], ' ', $params['subject'])
+    : NULL;
+
+  // Assign email body and optional parameters.
+  $message['body'] = $params['body'];
   $message['params'] = isset($params['params']) ?? $params['params'];
 }
 
 /**
  * Implements hook_preprocess_HOOK().
  */
-function dhsc_result_viewer_preprocess_mimemail_message(&$variables) {
+function dhsc_result_viewer_preprocess_mimemail_message(array &$variables) {
   $variables['base_url'] = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
 }
 
 /**
  * Implements hook_preprocess_HOOK().
- *
- * @param $variables
  */
-function dhsc_result_viewer_preprocess_status_messages(&$variables) {
+function dhsc_result_viewer_preprocess_status_messages(array &$variables) {
+  // Check for status messages in the message list.
   if (isset($variables['message_list']['status'])) {
     $status_messages = $variables['message_list']['status'];
     foreach ($status_messages as $key => $message) {
+
       // Remove status message if updating submission.
       if (strpos((string) $message, 'Submission updated') !== FALSE) {
         unset($variables['message_list']['status'][$key]);
@@ -204,8 +199,16 @@ function dhsc_result_viewer_preprocess_status_messages(&$variables) {
 /**
  * Implements hook_webform_submission_form_alter().
  */
-function dhsc_result_viewer_webform_submission_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (in_array($form['#webform_id'], ['self_assessment_tool', 'assured_solutions_tool', 'dsf_tool', 'dsf_tool_advanced']) && ($current_page = $form_state->get('current_page')) !== '') {
+function dhsc_result_viewer_webform_submission_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
+  // Target specific webforms.
+  if (in_array($form['#webform_id'], [
+    'self_assessment_tool',
+    'assured_solutions_tool',
+    'dsf_tool',
+    'dsf_tool_advanced',
+  ]) && ($current_page = $form_state->get('current_page')) !== '') {
+
+    // Add a hidden form element to track the current step.
     $form['current_step'] = [
       '#type' => 'value',
       '#value' => $current_page,
@@ -217,7 +220,12 @@ function dhsc_result_viewer_webform_submission_form_alter(&$form, FormStateInter
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function dhsc_result_viewer_theme_suggestions_webform_submission_form_alter(array &$suggestions, array $variables, $hook) {
-  if (in_array($variables['form']['#webform_id'], ['self_assessment_tool', 'assured_solutions_tool', 'dsf_tool', 'dsf_tool_advanced'])) {
+  if (in_array($variables['form']['#webform_id'], [
+    'self_assessment_tool',
+    'assured_solutions_tool',
+    'dsf_tool',
+    'dsf_tool_advanced',
+  ])) {
     $suggestions[] = $variables['form']['#webform_id'] . '__' . $variables['form']['current_step']['#value'];
   }
 }

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
@@ -1,6 +1,10 @@
 <?php
 
-use \Drupal\Core\Form\FormStateInterface;
+/**
+ * @file
+ */
+
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
 /**
@@ -11,8 +15,7 @@ use Drupal\Core\Url;
 /**
  * Implements hook_theme().
  */
-function dhsc_result_viewer_theme()
-{
+function dhsc_result_viewer_theme() {
   return [
     'dhsc_results_list_assured_solutions' => [
       'variables' => [
@@ -83,7 +86,7 @@ function dhsc_result_viewer_theme()
         'title' => NULL,
         'url' => NULL,
         'answers' => [
-          'answer' => NULL
+          'answer' => NULL,
         ],
       ],
     ],
@@ -141,11 +144,10 @@ function dhsc_result_viewer_theme()
  * Implements hook_form_alter().
  *
  * @param [type] $form
- * @param FormStateInterface $form_state
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
  * @param [type] $form_id
  */
-function dhsc_result_viewer_form_alter(&$form, FormStateInterface $form_state, $form_id)
-{
+function dhsc_result_viewer_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Re-write submit label when re-submitting answers.
   $form_ids = [
     'webform_submission_assured_solutions_tool_edit_form',
@@ -166,8 +168,7 @@ function dhsc_result_viewer_form_alter(&$form, FormStateInterface $form_state, $
 /**
  * Implements hook_mail().
  */
-function dhsc_result_viewer_mail($key, &$message, $params)
-{
+function dhsc_result_viewer_mail($key, &$message, $params) {
   $message['from'] = $params['headers']['From'] ?? NULL;
   // Strip newline characters from email subjects.
   $message['subject'] = isset($params['subject']) ? str_replace(["\r\n", "\r", "\n"], ' ', $params['subject']) : NULL;
@@ -203,12 +204,11 @@ function dhsc_result_viewer_preprocess_status_messages(&$variables) {
 /**
  * Implements hook_webform_submission_form_alter().
  */
-function dhsc_result_viewer_webform_submission_form_alter(&$form, FormStateInterface $form_state, $form_id)
-{
+function dhsc_result_viewer_webform_submission_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (in_array($form['#webform_id'], ['self_assessment_tool', 'assured_solutions_tool', 'dsf_tool', 'dsf_tool_advanced']) && ($current_page = $form_state->get('current_page')) !== '') {
     $form['current_step'] = [
       '#type' => 'value',
-      '#value' =>  $current_page,
+      '#value' => $current_page,
     ];
   }
 }
@@ -216,8 +216,7 @@ function dhsc_result_viewer_webform_submission_form_alter(&$form, FormStateInter
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
-function dhsc_result_viewer_theme_suggestions_webform_submission_form_alter(array &$suggestions, array $variables, $hook)
-{
+function dhsc_result_viewer_theme_suggestions_webform_submission_form_alter(array &$suggestions, array $variables, $hook) {
   if (in_array($variables['form']['#webform_id'], ['self_assessment_tool', 'assured_solutions_tool', 'dsf_tool', 'dsf_tool_advanced'])) {
     $suggestions[] = $variables['form']['#webform_id'] . '__' . $variables['form']['current_step']['#value'];
   }
@@ -226,8 +225,7 @@ function dhsc_result_viewer_theme_suggestions_webform_submission_form_alter(arra
 /**
  * Implements hook_theme_preprocess_HOOK().
  */
-function dhsc_result_viewer_preprocess_self_assessment_tool__step_1(&$variables)
-{
+function dhsc_result_viewer_preprocess_self_assessment_tool__step_1(&$variables) {
   // Get tool landing page uri from config.
   $config = \Drupal::config('dhsc_result_viewer.result_summary_settings');
   $landing_page_uri = $config->get('sa_landing_page');
@@ -239,8 +237,7 @@ function dhsc_result_viewer_preprocess_self_assessment_tool__step_1(&$variables)
 /**
  * Implements hook_theme_preprocess_HOOK().
  */
-function dhsc_result_viewer_preprocess_assured_solutions_tool__step_1(&$variables)
-{
+function dhsc_result_viewer_preprocess_assured_solutions_tool__step_1(&$variables) {
   // Get tool landing page uri from config.
   $config = \Drupal::config('dhsc_result_viewer.result_summary_settings');
   $landing_page_uri = $config->get('as_landing_page');
@@ -252,14 +249,13 @@ function dhsc_result_viewer_preprocess_assured_solutions_tool__step_1(&$variable
 /**
  * Implements hook_theme_preprocess_HOOK().
  */
-function dhsc_result_viewer_preprocess_dsf_tool__step_1(&$variables)
-{
+function dhsc_result_viewer_preprocess_dsf_tool__step_1(&$variables) {
   // Get tool landing page uri from config.
   $config = \Drupal::config('dhsc_result_viewer.result_summary_settings');
   $landing_page_uri = $config->get('dsf_landing_page');
 
   // Pass url from config for back behaviour.
-  if($landing_page_uri) {
+  if ($landing_page_uri) {
     $variables['link'] = Url::fromUserInput($landing_page_uri, ['absolute' => TRUE]);
   }
 }
@@ -267,14 +263,13 @@ function dhsc_result_viewer_preprocess_dsf_tool__step_1(&$variables)
 /**
  * Implements hook_theme_preprocess_HOOK().
  */
-function dhsc_result_viewer_preprocess_dsf_tool_advanced__step_1(&$variables)
-{
+function dhsc_result_viewer_preprocess_dsf_tool_advanced__step_1(&$variables) {
   // Get tool landing page uri from config.
   $config = \Drupal::config('dhsc_result_viewer.result_summary_settings');
   $landing_page_uri = $config->get('dsf_advanced_landing_page');
 
   // Pass url from config for back behaviour.
-  if($landing_page_uri) {
+  if ($landing_page_uri) {
     $variables['link'] = Url::fromUserInput($landing_page_uri, ['absolute' => TRUE]);
   }
 }

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.services.yml
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.services.yml
@@ -2,26 +2,21 @@ services:
   dhsc_self_assessment_result_viewer.service:
     class: Drupal\dhsc_result_viewer\SelfAssessmentResultViewer
     arguments: ['@entity_type.manager', '@config.factory', '@tempstore.private']
+
   dhsc_assured_solutions_result_viewer.service:
     class: Drupal\dhsc_result_viewer\AssuredSolutionsResultViewer
-    arguments: ['@entity_type.manager', '@config.factory', '@tempstore.private']
-<<<<<<< Updated upstream
-  dhsc_dsf_result_viewer.service:
-    class: Drupal\dhsc_result_viewer\dsfResultViewer
-    arguments: [ '@entity_type.manager', '@config.factory', '@tempstore.private' ]
-=======
-<<<<<<< Updated upstream
-=======
+    arguments: ['@entity_type.manager', '@config.factory', '@tempstore.private', '@path_alias.manager', '@entity.query.sql', '@request_stack']
+
   dhsc_dsf_result_viewer.service:
     class: Drupal\dhsc_result_viewer\DSFResultViewer
-    arguments: [ '@entity_type.manager', '@config.factory', '@tempstore.private' ]
->>>>>>> Stashed changes
->>>>>>> Stashed changes
+    arguments: ['@entity_type.manager', '@config.factory', '@tempstore.private']
+
   dhsc_result_viewer.breadcrumb:
     class: Drupal\dhsc_result_viewer\Breadcrumb\SelfAssessmentBreadcrumbBuilder
     arguments: ['@string_translation']
     tags:
-      - { name: breadcrumb_builder, priority: 1008}
+      - { name: breadcrumb_builder, priority: 1008 }
+
   dhsc_result_viewer.dompdf_generator:
     class: \Drupal\dhsc_result_viewer\DhscDomPdfGenerator
-    arguments: ['@renderer', '@request_stack', '@module_handler','@extension.list.module', '@file_system']
+    arguments: ['@renderer', '@request_stack', '@module_handler', '@extension.list.module', '@file_system']

--- a/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsInterface.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsInterface.php
@@ -18,8 +18,9 @@ interface AssuredSolutionsInterface {
    *   Webform entity.
    *
    * @return mixed
+   *   Returns result summary values.
    */
-  public function getResultsSummary($data, $webform);
+  public function getResultsSummary(array $data, $webform);
 
   /**
    * Get webform submission id.
@@ -46,10 +47,10 @@ interface AssuredSolutionsInterface {
    * @return array
    *   Return result node ids.
    */
-  public function getResultNodes($answers);
+  public function getResultNodes(array $answers);
 
   /**
-   * Returns all suplier nodes which do not match user search criteria.
+   * Returns all supplier nodes which do not match user search criteria.
    *
    * @param array $nids
    *   Result node nids.
@@ -57,6 +58,6 @@ interface AssuredSolutionsInterface {
    * @return array
    *   Return non matching nids.
    */
-  public function getNonMatches($nids);
+  public function getNonMatches(array $nids);
 
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsInterface.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsInterface.php
@@ -39,8 +39,10 @@ interface AssuredSolutionsInterface {
 
   /**
    * Returns webform result nodes which contain at least one answer.
+   *
    * @param array $answers
    *   User supplied answers.
+   *
    * @return array
    *   Return result node ids.
    */
@@ -48,8 +50,10 @@ interface AssuredSolutionsInterface {
 
   /**
    * Returns all suplier nodes which do not match user search criteria.
+   *
    * @param array $nids
    *   Result node nids.
+   *
    * @return array
    *   Return non matching nids.
    */

--- a/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsResultViewer.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsResultViewer.php
@@ -463,8 +463,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface {
    *   Return webform url.
    */
   protected function getWebFormUrl() {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    if ($submission = $this->getSubmission()) {
+    if ($this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
       $webform = $this->getSubmission()->getWebform();
       if ($webform) {
@@ -480,8 +479,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface {
    *   Return webform confirmation page path.
    */
   protected function getConfirmationPagePath() {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    if ($submission = $this->getSubmission()) {
+    if ($this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
       $webform = $this->getSubmission()->getWebform();
       if (!$webform) {

--- a/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsResultViewer.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/AssuredSolutionsResultViewer.php
@@ -15,8 +15,7 @@ use Drupal\webform\Utility\WebformOptionsHelper;
  *
  * @package Drupal\dhsc_assured_solutions_result_viewer
  */
-class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
-{
+class AssuredSolutionsResultViewer implements AssuredSolutionsInterface {
 
   /**
    * Entity type manager.
@@ -100,16 +99,14 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
   /**
    * {@inheritdoc}
    */
-  public function getCategories()
-  {
+  public function getCategories() {
     return $this->taxonomyStorage->loadTree('category', 0, NULL, TRUE);;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getResultsSummary($data, $webform)
-  {
+  public function getResultsSummary($data, $webform) {
     $results = $this->getResultIds($data, $webform);
 
     if (!$results) {
@@ -172,8 +169,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    * @return array
    *   Return result ids.
    */
-  protected function getResultIds(array $data, $webform)
-  {
+  protected function getResultIds(array $data, $webform) {
     $answers = [];
     $search_criteria = [];
     $field_key = NULL;
@@ -185,7 +181,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
     }
 
     foreach ($data as $key => $answer) {
-      // check we have an answer value in both checkboxes and radio form fields.
+      // Check we have an answer value in both checkboxes and radio form fields.
       if ($answer === '0' || empty($answer)) {
         continue;
       }
@@ -210,7 +206,8 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
           $value = WebformOptionsHelper::getOptionsText((array) $value, $element['#options']);
           if (count($value) > 1) {
             $item = $value;
-          } elseif (count($value) === 1) {
+          }
+          elseif (count($value) === 1) {
             $item = reset($value);
           }
           $section = $webform->getElement($element['#webform_parent_key'])['#title'];
@@ -231,8 +228,8 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
       $matches = [];
       $nids = [];
 
-      // check against non possible answers values on the supplier node to
-      // further refine matches
+      // Check against non possible answers values on the supplier node to
+      // further refine matches.
       $matches = array_filter($nodes, function ($node) use ($answers) {
         $fieldItems = $node->get('field_non_possible_answers')->getValue();
         foreach ($fieldItems as $value) {
@@ -246,7 +243,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
         return $node->id();
       }, $matches);
 
-      // query for all supplier nodes where there is no match
+      // Query for all supplier nodes where there is no match.
       $nids = array_unique($nids);
 
       $results = $this->getNonMatches($nids);
@@ -305,10 +302,10 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    * Returns all result nodes which contain at least one answer.
    *
    * @param array $answers
+   *
    * @return array
    */
-  public function getResultNodes($answers)
-  {
+  public function getResultNodes($answers) {
     $query = \Drupal::entityQuery('node')
       ->accessCheck(FALSE)
       ->condition('type', 'supplier')
@@ -330,14 +327,14 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    * Returns all supplier nodes which do not match user search criteria.
    *
    * @param array $nids
+   *
    * @return array
    */
-  public function getNonMatches($nids)
-  {
+  public function getNonMatches($nids) {
     $query = \Drupal::entityQuery('node')
-    ->accessCheck(FALSE)
-    ->condition('type', 'supplier')
-    ->condition('status', 1);
+      ->accessCheck(FALSE)
+      ->condition('type', 'supplier')
+      ->condition('status', 1);
     foreach ($nids as $nid) {
       $query->condition('nid', $nid, 'NOT IN');
     }
@@ -353,10 +350,10 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    *
    * @param string $value
    * @param object $webform
+   *
    * @return void
    */
-  public function getFormElementValue(string $field_key = NULL, $value, $webform)
-  {
+  public function getFormElementValue(string $field_key = NULL, $value, $webform) {
     $element = $field_key ? $webform->getElement($field_key) : $webform->getElement($value);
 
     if ($element === NULL) {
@@ -378,7 +375,8 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
       $value = WebformOptionsHelper::getOptionsText((array) $value, $element['#options']);
       if (count($value) > 1) {
         $item = $value;
-      } elseif (count($value) === 1) {
+      }
+      elseif (count($value) === 1) {
         $item = reset($value);
       }
       return [
@@ -391,7 +389,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
   /**
    * Get id of result node.
    *
-   * @param TermInterface $term
+   * @param \Drupal\taxonomy\TermInterface $term
    *   Category term.
    * @param array $data
    *   Webform values.
@@ -399,8 +397,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    * @return array|int|void
    *   Return result ids.
    */
-  protected function getResultId(TermInterface $term, array $data)
-  {
+  protected function getResultId(TermInterface $term, array $data) {
     if ($term->bundle() != 'category') {
       return;
     }
@@ -424,24 +421,21 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
   /**
    * {@inheritdoc}
    */
-  public function getSubmissionId()
-  {
+  public function getSubmissionId() {
     return $this->tempStore->get('sid');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function questionsAllReset()
-  {
+  public function questionsAllReset() {
     return $this->tempStore->set('yes_to_all_questions', NULL);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getSubmission()
-  {
+  public function getSubmission() {
     $sid = $this->getSubmissionId();
     if ($sid) {
       $submission = $this->entityTypeManager->getStorage('webform_submission')->load($sid);
@@ -449,15 +443,13 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
     }
   }
 
-
   /**
    * Get webform submission data.
    *
    * @return array
    *   Return webform submission data.
    */
-  protected function getSubmissionData()
-  {
+  protected function getSubmissionData() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->getSubmission()) {
       return $submission->getData();
@@ -470,8 +462,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    * @return \Drupal\Core\GeneratedUrl|string
    *   Return webform url.
    */
-  protected function getWebFormUrl()
-  {
+  protected function getWebFormUrl() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
@@ -488,8 +479,7 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
    * @return mixed|void
    *   Return webform confirmation page path.
    */
-  protected function getConfirmationPagePath()
-  {
+  protected function getConfirmationPagePath() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
@@ -508,4 +498,5 @@ class AssuredSolutionsResultViewer implements AssuredSolutionsInterface
       return $raw_data['settings']['page_confirm_path'];
     }
   }
+
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
@@ -2,16 +2,16 @@
 
 namespace Drupal\dhsc_result_viewer\Breadcrumb;
 
-use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\webform\Entity\Webform;
 
 /**
- *
+ * Class SelfAssessmentBreadcrumbBuilder.
  */
 class SelfAssessmentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 

--- a/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Breadcrumb/SelfAssessmentBreadcrumbBuilder.php
@@ -10,6 +10,9 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\webform\Entity\Webform;
 
+/**
+ *
+ */
 class SelfAssessmentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
   use StringTranslationTrait;

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/DhscGeneratePdf.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/DhscGeneratePdf.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Extension\ExtensionPathResolver;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\dhsc_result_viewer\DhscDomPdfGenerator;
@@ -47,9 +48,16 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
   /**
    * TempStore.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
   protected $tempStore;
+
+  /**
+   * The extension path resolver service.
+   *
+   * @var \Drupal\Core\Extension\ExtensionPathResolver
+   */
+  protected $extensionPathResolver;
 
   /**
    * GeneratePdf constructor.
@@ -60,21 +68,27 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
    *   The renderer service.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The configuration factory service.
-   * @param \Drupal\tsp_result_viewer\ResultViewerInterface $result_viewer
-   * @param \Drupal\tsp_result_viewer\TspDomPdfGenerator $dompdf_generator
+   * @param \Drupal\dhsc_result_viewer\DhscDomPdfGenerator $dompdf_generator
+   *   The DOMPDF generator service for creating PDF documents.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store
+   *   The TempStore factory service.
+   * @param \Drupal\Core\Extension\ExtensionPathResolver $extension_path_resolver
+   *   The extension path resolver service.
    */
   public function __construct(
     EntityTypeManager $entityTypeManager,
     Renderer $renderer,
     ConfigFactoryInterface $configFactory,
     DhscDomPdfGenerator $dompdf_generator,
-    PrivateTempStoreFactory $temp_store
+    PrivateTempStoreFactory $temp_store,
+    ExtensionPathResolver $extension_path_resolver,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->renderer = $renderer;
     $this->configFactory = $configFactory;
     $this->dompdfGenerator = $dompdf_generator;
     $this->tempStore = $temp_store;
+    $this->extensionPathResolver = $extension_path_resolver;
   }
 
   /**
@@ -86,7 +100,8 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
       $container->get('renderer'),
       $container->get('config.factory'),
       $container->get('dhsc_result_viewer.dompdf_generator'),
-      $container->get('tempstore.private')
+      $container->get('tempstore.private'),
+      $container->get('extension.path.resolver')
     );
   }
 
@@ -100,10 +115,9 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
    */
   public function generate() {
     $content = $this->getContent();
-    $pdf_generator = $this->dompdfGenerator;
-    $stylesheet = \Drupal::service('extension.path.resolver')->getPath('module', 'dhsc_result_viewer') . '/css/style.css';
+    $stylesheet = $this->extensionPathResolver->getPath('module', 'dhsc_result_viewer') . '/css/style.css';
     $filename = 'dhsc-assured-solutions-results';
-    $response = $pdf_generator->getResponse($filename, $content, FALSE, [], 'A4', 0, 0, 0, 'portrait', NULL, $stylesheet);
+    $response = $this->dompdfGenerator->getResponse($filename, $content, FALSE, [], 'A4', 0, 0, 0, 'portrait', NULL, $stylesheet);
 
     return $response;
   }
@@ -116,12 +130,10 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
    */
   protected function getSubmissionResult() {
     // Get saved result data from tempstore.
-    // $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');.
     $result_data = $this->tempStore->get('dhsc_result_viewer')->get('assured_solutions_result_data');
-    $data = ResultSummaryAssuredSolutionsController::buildResultMarkup($result_data, $pdf = TRUE);
+    $data = ResultSummaryAssuredSolutionsController::buildResultMarkup($result_data, TRUE);
 
     return $data;
-
   }
 
   /**
@@ -131,7 +143,6 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
    *   Render array.
    */
   protected function getContent() {
-
     $results = $this->getSubmissionResult();
 
     return [

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/DhscGeneratePdf.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/DhscGeneratePdf.php
@@ -6,18 +6,15 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Render\Markup;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\dhsc_result_viewer\DhscDomPdfGenerator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\dhsc_result_viewer\Controller\ResultSummaryAssuredSolutionsController;
 
 /**
  * Class DhscGeneratePdf.
  */
-class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterface
-{
+class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterface {
 
   /**
    * The entity type manager.
@@ -53,7 +50,6 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
    * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
-
 
   /**
    * GeneratePdf constructor.
@@ -120,9 +116,9 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
    */
   protected function getSubmissionResult() {
     // Get saved result data from tempstore.
-    // $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
+    // $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');.
     $result_data = $this->tempStore->get('dhsc_result_viewer')->get('assured_solutions_result_data');
-    $data = ResultSummaryAssuredSolutionsController::buildResultMarkup($result_data, $pdf=TRUE);
+    $data = ResultSummaryAssuredSolutionsController::buildResultMarkup($result_data, $pdf = TRUE);
 
     return $data;
 
@@ -143,4 +139,5 @@ class DhscGeneratePdf extends ControllerBase implements ContainerInjectionInterf
       '#content' => $results,
     ];
   }
+
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummaryAssuredSolutionsController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummaryAssuredSolutionsController.php
@@ -22,8 +22,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  *
  * @package Drupal\dhsc_result_viewer\Controller
  */
-class ResultSummaryAssuredSolutionsController extends ControllerBase
-{
+class ResultSummaryAssuredSolutionsController extends ControllerBase {
 
   /**
    * Entity Type Manager.
@@ -109,8 +108,7 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container)
-  {
+  public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('config.factory'),
@@ -128,8 +126,7 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
    * @return mixed
    *   Resurn submission results.
    */
-  public function getResults()
-  {
+  public function getResults() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->resultViewer->getSubmission()) {
       return $this->resultViewer->getResultsSummary($submission->getData(), $submission->getWebform());
@@ -142,8 +139,7 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
    * @return array
    *   Return render array.
    */
-  public function build()
-  {
+  public function build() {
     $config = $this->configFactory->get(ResultSummaryForm::SETTINGS);
 
     if ($result = $this->getResults()) {
@@ -158,9 +154,10 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
         '#no_matches' => $result['no_matches'],
         '#result' => $result['result_items'],
         '#email_form' => !empty($result['total_count']) ? \Drupal::formBuilder()->getForm('Drupal\dhsc_result_viewer\Form\ResultEmailForm') : FALSE,
-        '#download_results_path' => Url::fromRoute('dhsc_result_viewer.generate_pdf')->toString()
+        '#download_results_path' => Url::fromRoute('dhsc_result_viewer.generate_pdf')->toString(),
       ];
-    } else {
+    }
+    else {
       $element = [
         '#theme' => 'dhsc_results_list_assured_solutions',
         '#title' => $config->get('title') ? $config->get('title') : NULL,
@@ -176,10 +173,10 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
    * Email submission results.
    *
    * @param string $email
+   *
    * @return void
    */
-  public function sendResultEmail($email, $token)
-  {
+  public function sendResultEmail($email, $token) {
 
     $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
 
@@ -198,8 +195,9 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
       try {
         $this->mailManager->mail($module, $key, $to, $langcode, $params, NULL, TRUE);
         \Drupal::logger('dhsc_result_viewer')->notice('assured solutions result email sent to ' . $email);
-      } catch (Exception $e) {
-        $message = t('There was a problem sending assured solutions result email to @email', array('@email' => $email));
+      }
+      catch (Exception $e) {
+        $message = t('There was a problem sending assured solutions result email to @email', ['@email' => $email]);
         \Drupal::logger('Error in email sending')->error($message);
         \Drupal::logger('Error in email sending')->error($e);
       }
@@ -225,8 +223,7 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
    *
    * @return array
    */
-  public static function buildResultMarkup($results, $pdf = FALSE)
-  {
+  public static function buildResultMarkup($results, $pdf = FALSE) {
     $criteria = '';
     if ($results['search_criteria']) {
       foreach ($results['search_criteria'] as $item) {
@@ -243,7 +240,8 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
       foreach ($results['matches'] as $node) {
         if ($node->get('field_body_paragraphs')->entity->getType() === 'localgov_text') {
           $summary = $node->get('field_body_paragraphs')->entity->get('localgov_text')->value;
-        } else {
+        }
+        else {
           $summary = '';
         }
         $result_items .= "<h4>
@@ -275,7 +273,7 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
     if ($pdf) {
 
       if ($non_matching_count) {
-      $non_matching_html = Markup::create("<div class='non-matches'><h3>
+        $non_matching_html = Markup::create("<div class='non-matches'><h3>
       {$non_matching_count}</h3>
       {$no_matches}
       </div>");
@@ -293,7 +291,7 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
     if (!$pdf) {
 
       if ($non_matching_count) {
-      $non_matching_html = Markup::create("<tr class='non-matches'><td><h3>
+        $non_matching_html = Markup::create("<tr class='non-matches'><td><h3>
       {$non_matching_count}</h3>
       {$no_matches}</td>
       </tr>");
@@ -309,4 +307,5 @@ class ResultSummaryAssuredSolutionsController extends ControllerBase
 
     return $params['body'];
   }
+
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummaryAssuredSolutionsController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummaryAssuredSolutionsController.php
@@ -10,6 +10,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\dhsc_result_viewer\AssuredSolutionsInterface;

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummaryDSFController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummaryDSFController.php
@@ -5,15 +5,19 @@ namespace Drupal\dhsc_result_viewer\Controller;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\dhsc_result_viewer\DSFInterface;
 use Drupal\dhsc_result_viewer\Form\ResultSummaryForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class ResultSummaryController for DSF forms.
@@ -65,6 +69,34 @@ class ResultSummaryDSFController extends ControllerBase {
   protected $messenger;
 
   /**
+   * The TempStore factory service.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStore;
+
+  /**
+   * The form builder service.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The logger factory service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * The request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
    * ResultSummaryController constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -73,6 +105,20 @@ class ResultSummaryDSFController extends ControllerBase {
    *   The configuration factory.
    * @param \Drupal\dhsc_dsf_result_viewer\DSFInterface $result_viewer
    *   ResultViewer service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   * @param \Drupal\Core\Mail\MailManagerInterface $mail_manager
+   *   The mail manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store
+   *   The TempStore factory service.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The form builder service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -81,6 +127,10 @@ class ResultSummaryDSFController extends ControllerBase {
     LanguageManagerInterface $language_manager,
     MailManagerInterface $mail_manager,
     MessengerInterface $messenger,
+    PrivateTempStoreFactory $temp_store,
+    FormBuilderInterface $form_builder,
+    LoggerChannelFactoryInterface $logger_factory,
+    RequestStack $request_stack,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->configFactory = $config_factory;
@@ -88,6 +138,10 @@ class ResultSummaryDSFController extends ControllerBase {
     $this->languageManager = $language_manager;
     $this->mailManager = $mail_manager;
     $this->messenger = $messenger;
+    $this->tempStore = $temp_store;
+    $this->formBuilder = $form_builder;
+    $this->loggerFactory = $logger_factory;
+    $this->requestStack = $request_stack;
   }
 
   /**
@@ -101,6 +155,10 @@ class ResultSummaryDSFController extends ControllerBase {
       $container->get('language_manager'),
       $container->get('plugin.manager.mail'),
       $container->get('messenger'),
+      $container->get('tempstore.private'),
+      $container->get('form_builder'),
+      $container->get('logger.factory'),
+      $container->get('request_stack')
     );
   }
 
@@ -130,14 +188,14 @@ class ResultSummaryDSFController extends ControllerBase {
     $webform = $submission->getWebform();
 
     // Extract unique submission token value from URL.
-    if ($submission_token = \Drupal::request()->query->get('token')) {
+    if ($submission_token = $this->requestStack->getCurrentRequest()->query->get('token')) {
       $webform_url = Url::fromRoute('entity.webform.canonical', ['webform' => $webform->id()])->toString();
       $submission_url = Url::fromUserInput($webform_url, ['query' => ['token' => $submission_token]])->toString();
     }
 
     if ($result = $this->getResults($submission)) {
 
-      $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
+      $tempStore = $this->tempStore->get('dhsc_result_viewer');
 
       // Save result data in tempstore for email result behaviour.
       $tempStore->set('dsf_result_data', $result);
@@ -149,7 +207,7 @@ class ResultSummaryDSFController extends ControllerBase {
         '#summary' => $config->get('dsf_result_summary') ? $config->get('dsf_result_summary') : NULL,
         '#result' => $result,
         '#submission_url' => $submission_url ?? NULL,
-        '#email_form' => \Drupal::formBuilder()->getForm('Drupal\dhsc_result_viewer\Form\ResultEmailForm'),
+        '#email_form' => $this->formBuilder->getForm('Drupal\dhsc_result_viewer\Form\ResultEmailForm'),
       ];
     }
     else {
@@ -168,25 +226,28 @@ class ResultSummaryDSFController extends ControllerBase {
    * Email submission results.
    *
    * @param string $email
+   *   The email address.
+   * @param string $token
+   *   The token.
    *
-   * @return void
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   The response.
    */
   public function sendResultEmail($email, $token) {
-    $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
+    $tempStore = $this->tempStore->get('dhsc_result_viewer');
 
     // Get saved result data from tempstore.
     $results = $tempStore->get('dsf_result_data');
 
     if (!empty($results)) {
-
       $result = $this->buildEmail($email, $results);
 
       if (!$result['result']) {
-        $message = t('There was a problem sending what good looks like result email to @email', ['@email' => $email]);
-        \Drupal::logger('Error in email sending')->error($message);
+        $message = $this->t('There was a problem sending what good looks like result email to @email', ['@email' => $email]);
+        $this->loggerFactory->get('Error in email sending')->error($message);
       }
       else {
-        \Drupal::logger('dhsc_result_viewer')->notice('what good looks like result email sent to ' . $email);
+        $this->loggerFactory->get('dhsc_result_viewer')->notice('what good looks like result email sent to ' . $email);
       }
 
       $submission_url = Url::fromRoute(
@@ -198,26 +259,30 @@ class ResultSummaryDSFController extends ControllerBase {
         new RedirectResponse($submission_url) :
         new RedirectResponse('/');
 
-      $this->messenger->addStatus(t('Email sent'));
+      $this->messenger->addStatus($this->t('Email sent'));
 
       return $response;
     }
-    $this->messenger->addError(t('Unable to send email'));
+    $this->messenger->addError($this->t('Unable to send email'));
   }
 
   /**
    * Construct results email.
    *
    * @param string $email
+   *   The email address.
+   * @param array $results
+   *   Results array.
    *
    * @return array
+   *   Array containing all details of the message.
    */
-  public function buildEmail($email, $results) {
+  public function buildEmail($email, array $results) {
     $module = 'dhsc_result_viewer';
     $key = 'email_result';
     $to = $email;
     $langcode = $this->languageManager->getDefaultLanguage()->getId();
-    $params['subject'] = t('Get started with email recommendations');
+    $params['subject'] = $this->t('Get started with email recommendations');
 
     $result_items = '';
     if ($results) {

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummarySelfAssessmentController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummarySelfAssessmentController.php
@@ -20,8 +20,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  *
  * @package Drupal\dhsc_result_viewer\Controller
  */
-class ResultSummarySelfAssessmentController extends ControllerBase
-{
+class ResultSummarySelfAssessmentController extends ControllerBase {
 
   /**
    * Entity Type Manager.
@@ -65,7 +64,6 @@ class ResultSummarySelfAssessmentController extends ControllerBase
    */
   protected $messenger;
 
-
   /**
    * ResultSummaryController constructor.
    *
@@ -95,8 +93,7 @@ class ResultSummarySelfAssessmentController extends ControllerBase
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container)
-  {
+  public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('config.factory'),
@@ -113,8 +110,7 @@ class ResultSummarySelfAssessmentController extends ControllerBase
    * @return mixed
    *   Resurn submission results.
    */
-  public function getResults($submission)
-  {
+  public function getResults($submission) {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission) {
       return $this->resultViewer->getResultsSummary($submission->getData());
@@ -127,14 +123,13 @@ class ResultSummarySelfAssessmentController extends ControllerBase
    * @return array
    *   Return render array.
    */
-  public function build()
-  {
+  public function build() {
     $config = $this->configFactory->get(ResultSummaryForm::SETTINGS);
 
     // Get the value from tempstore if we need to display a result variant.
     $result_variant = $this->resultViewer->questionsAllYes();
 
-    // Reset the value if question choices are edited
+    // Reset the value if question choices are edited.
     // @todo may need to do this on another action
     $this->resultViewer->questionsAllReset();
 
@@ -163,7 +158,8 @@ class ResultSummarySelfAssessmentController extends ControllerBase
         '#submission_url' => isset($submission_url) ? $submission_url : NULL,
         '#email_form' => \Drupal::formBuilder()->getForm('Drupal\dhsc_result_viewer\Form\ResultEmailForm'),
       ];
-    } else {
+    }
+    else {
       $element = [
         '#theme' => 'dhsc_results_list_self_assessment',
         '#title' => $config->get('title') ? $config->get('title') : NULL,
@@ -179,10 +175,10 @@ class ResultSummarySelfAssessmentController extends ControllerBase
    * Email submission results.
    *
    * @param string $email
+   *
    * @return void
    */
-  public function sendResultEmail($email, $token)
-  {
+  public function sendResultEmail($email, $token) {
     $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
 
     // Get saved result data from tempstore.
@@ -193,9 +189,10 @@ class ResultSummarySelfAssessmentController extends ControllerBase
       $result = $this->buildEmail($email, $results);
 
       if (!$result['result']) {
-        $message = t('There was a problem sending self assessment result email to @email', array('@email' => $email));
+        $message = t('There was a problem sending self assessment result email to @email', ['@email' => $email]);
         \Drupal::logger('Error in email sending')->error($message);
-      } else {
+      }
+      else {
         \Drupal::logger('dhsc_result_viewer')->notice('self assessment result email sent to ' . $email);
       }
 
@@ -219,10 +216,10 @@ class ResultSummarySelfAssessmentController extends ControllerBase
    * Construct results email.
    *
    * @param string $email
+   *
    * @return array
    */
-  public function buildEmail($email, $results)
-  {
+  public function buildEmail($email, $results) {
     $module = 'dhsc_result_viewer';
     $key = 'email_result';
     $to = $email;
@@ -249,4 +246,5 @@ class ResultSummarySelfAssessmentController extends ControllerBase
 
     return $this->mailManager->mail($module, $key, $to, $langcode, $params, NULL, TRUE);
   }
+
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummarySelfAssessmentController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ResultSummarySelfAssessmentController.php
@@ -5,15 +5,19 @@ namespace Drupal\dhsc_result_viewer\Controller;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\dhsc_result_viewer\Form\ResultSummaryForm;
 use Drupal\dhsc_result_viewer\SelfAssessmentInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class ResultSummarySelfAssessmentController.
@@ -65,6 +69,34 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
   protected $messenger;
 
   /**
+   * The TempStore factory service.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * The form builder service.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The logger factory service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
    * ResultSummaryController constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -73,6 +105,20 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
    *   The configuration factory.
    * @param \Drupal\dhsc_self_assessment_result_viewer\SelfAssessmentInterface $result_viewer
    *   ResultViewer service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   * @param \Drupal\Core\Mail\MailManagerInterface $mail_manager
+   *   The mail manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The Messenger service.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The TempStore factory service.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The form builder service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -81,6 +127,10 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
     LanguageManagerInterface $language_manager,
     MailManagerInterface $mail_manager,
     MessengerInterface $messenger,
+    PrivateTempStoreFactory $temp_store_factory,
+    FormBuilderInterface $form_builder,
+    RequestStack $request_stack,
+    LoggerChannelFactoryInterface $logger_factory,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->configFactory = $config_factory;
@@ -88,6 +138,10 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
     $this->languageManager = $language_manager;
     $this->mailManager = $mail_manager;
     $this->messenger = $messenger;
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->formBuilder = $form_builder;
+    $this->requestStack = $request_stack;
+    $this->loggerFactory = $logger_factory;
   }
 
   /**
@@ -101,6 +155,10 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
       $container->get('language_manager'),
       $container->get('plugin.manager.mail'),
       $container->get('messenger'),
+      $container->get('tempstore.private'),
+      $container->get('form_builder'),
+      $container->get('request_stack'),
+      $container->get('logger.factory')
     );
   }
 
@@ -108,7 +166,7 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
    * Get submission results.
    *
    * @return mixed
-   *   Resurn submission results.
+   *   Return submission results.
    */
   public function getResults($submission) {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
@@ -137,14 +195,14 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
     $webform = $submission->getWebform();
 
     // Extract unique submission token value from URL.
-    if ($submission_token = \Drupal::request()->query->get('token')) {
+    if ($submission_token = $this->requestStack->getCurrentRequest()->query->get('token')) {
       $webform_url = Url::fromRoute('entity.webform.canonical', ['webform' => $webform->id()])->toString();
       $submission_url = Url::fromUserInput($webform_url, ['query' => ['token' => $submission_token]])->toString();
     }
 
     if ($result = $this->getResults($submission)) {
 
-      $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
+      $tempStore = $this->tempStoreFactory->get('dhsc_result_viewer');
 
       // Save result data in tempstore for email result behaviour.
       $tempStore->set('self_assessment_result_data', $result);
@@ -155,8 +213,8 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
         '#title' => $config->get('title') ? $config->get('title') : NULL,
         '#summary' => $config->get('sa_result_summary') ? $config->get('sa_result_summary') : NULL,
         '#result' => $result,
-        '#submission_url' => isset($submission_url) ? $submission_url : NULL,
-        '#email_form' => \Drupal::formBuilder()->getForm('Drupal\dhsc_result_viewer\Form\ResultEmailForm'),
+        '#submission_url' => $submission_url ?? NULL,
+        '#email_form' => $this->formBuilder->getForm('Drupal\dhsc_result_viewer\Form\ResultEmailForm'),
       ];
     }
     else {
@@ -175,25 +233,28 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
    * Email submission results.
    *
    * @param string $email
+   *   The email address.
+   * @param string $token
+   *   The token.
    *
-   * @return void
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   The response.
    */
   public function sendResultEmail($email, $token) {
-    $tempStore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
+    $tempStore = $this->tempStoreFactory->get('dhsc_result_viewer');
 
     // Get saved result data from tempstore.
     $results = $tempStore->get('self_assessment_result_data');
 
     if (!empty($results)) {
-
       $result = $this->buildEmail($email, $results);
 
       if (!$result['result']) {
-        $message = t('There was a problem sending self assessment result email to @email', ['@email' => $email]);
-        \Drupal::logger('Error in email sending')->error($message);
+        $message = $this->t('There was a problem sending self assessment result email to @email', ['@email' => $email]);
+        $this->loggerFactory->get('Error in email sending')->error($message);
       }
       else {
-        \Drupal::logger('dhsc_result_viewer')->notice('self assessment result email sent to ' . $email);
+        $this->loggerFactory->get('dhsc_result_viewer')->notice('self assessment result email sent to ' . $email);
       }
 
       $submission_url = Url::fromRoute(
@@ -205,26 +266,30 @@ class ResultSummarySelfAssessmentController extends ControllerBase {
         new RedirectResponse($submission_url) :
         new RedirectResponse('/');
 
-      $this->messenger->addStatus(t('Email sent'));
+      $this->messenger->addStatus($this->t('Email sent'));
 
       return $response;
     }
-    $this->messenger->addError(t('Unable to send email'));
+    $this->messenger->addError($this->t('Unable to send email'));
   }
 
   /**
    * Construct results email.
    *
    * @param string $email
+   *   The email address.
+   * @param array $results
+   *   Results array.
    *
    * @return array
+   *   Array containing all details of the message.
    */
-  public function buildEmail($email, $results) {
+  public function buildEmail(string $email, array $results) {
     $module = 'dhsc_result_viewer';
     $key = 'email_result';
     $to = $email;
     $langcode = $this->languageManager->getDefaultLanguage()->getId();
-    $params['subject'] = t('Get started with email recommendations');
+    $params['subject'] = $this->t('Get started with email recommendations');
 
     $result_items = '';
     if ($results) {

--- a/docroot/modules/custom/dhsc_result_viewer/src/DSFInterface.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/DSFInterface.php
@@ -16,8 +16,9 @@ interface DSFInterface {
    *   Webform values.
    *
    * @return mixed
+   *   Returns result summary values.
    */
-  public function getResultsSummary($data);
+  public function getResultsSummary(array $data);
 
   /**
    * Get sorts result ids.

--- a/docroot/modules/custom/dhsc_result_viewer/src/DSFResultViewer.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/DSFResultViewer.php
@@ -69,7 +69,9 @@ class DSFResultViewer implements DSFInterface {
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The private temp store factory.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -138,8 +140,6 @@ class DSFResultViewer implements DSFInterface {
    *
    * @param array $data
    *   Webform values.
-   * @param bool $top_tips
-   *   Check if top tip.
    *
    * @return array
    *   Return result ids.
@@ -161,6 +161,8 @@ class DSFResultViewer implements DSFInterface {
   /**
    * Get id of result node.
    *
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   Term entity.
    * @param array $data
    *   Webform values.
    *
@@ -222,8 +224,7 @@ class DSFResultViewer implements DSFInterface {
    *   Return webform url.
    */
   protected function getWebFormUrl() {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    if ($submission = $this->getSubmission()) {
+    if ($this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
       $webform = $this->getSubmission()->getWebform();
       if ($webform) {
@@ -239,18 +240,17 @@ class DSFResultViewer implements DSFInterface {
    *   Return webform confirmation page path.
    */
   protected function getConfirmationPagePath() {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    if ($submission = $this->getSubmission()) {
+    if ($this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
       $webform = $this->getSubmission()->getWebform();
       if (!$webform) {
-        return;
+        return NULL;
       }
 
       $config_name = $webform->getConfigDependencyName();
       $config = $this->configFactory->get($config_name);
       if (!$config) {
-        return;
+        return NULL;
       }
       $raw_data = $config->getRawData();
 

--- a/docroot/modules/custom/dhsc_result_viewer/src/DhscDomPdfGenerator.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/DhscDomPdfGenerator.php
@@ -3,19 +3,18 @@
 namespace Drupal\dhsc_result_viewer;
 
 use Dompdf\Dompdf;
-use Drupal\Core\Render\Markup;
 use Drupal\pdf_generator\DomPdfGenerator;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Defines helpers methods to help in managing config which used in SCity.
  */
-class DhscDomPdfGenerator extends DomPdfGenerator
-{
+class DhscDomPdfGenerator extends DomPdfGenerator {
+
   /**
    * @inheritDoc
    */
-  public function getResponse($title, array $content, $preview = FALSE, array $options = [], $pageSize = 'A4', $showPagination = 0, $paginationX = 0, $paginationY = 0, $disposition = 'portrait', $cssText = NULL, $cssPath = NULL, $forceDownload = TRUE){
+  public function getResponse($title, array $content, $preview = FALSE, array $options = [], $pageSize = 'A4', $showPagination = 0, $paginationX = 0, $paginationY = 0, $disposition = 'portrait', $cssText = NULL, $cssPath = NULL, $forceDownload = TRUE) {
     $request = $this->requestStack->getCurrentRequest();
     $base_url = $request->getSchemeAndHttpHost();
 
@@ -55,17 +54,18 @@ class DhscDomPdfGenerator extends DomPdfGenerator
 
     if (function_exists('utf8_decode')) {
       $html = utf8_decode($html);
-    } elseif (function_exists('mb_convert_encoding')) {
+    }
+    elseif (function_exists('mb_convert_encoding')) {
       $html = mb_convert_encoding($html, 'ISO-8859-1', 'UTF-8');
     }
     $html = htmlspecialchars_decode(htmlentities($html, ENT_NOQUOTES, 'ISO-8859-1'), ENT_NOQUOTES);
 
-    //    $html = str_replace('src="' . $base_url . '/', 'src="/', $html);
-    //    $html = str_replace('href="/', 'href="' . $base_url . '/', $html);
+    // $html = str_replace('src="' . $base_url . '/', 'src="/', $html);
+    //    $html = str_replace('href="/', 'href="' . $base_url . '/', $html);.
     $html = str_replace('src="/', 'src="' . $base_url . '/', $html);
     $html = str_replace('&nbsp;', ' ', $html);
 
-    //    echo $base_url;
+    // Echo $base_url;
     //    echo $html;
     //    exit();
     $this->dompdf->setOptions($this->options);
@@ -81,4 +81,5 @@ class DhscDomPdfGenerator extends DomPdfGenerator
     $response->headers->set('Content-Disposition', "attachment; filename={$title}.pdf");
     return $response;
   }
+
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/DhscDomPdfGenerator.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/DhscDomPdfGenerator.php
@@ -60,14 +60,9 @@ class DhscDomPdfGenerator extends DomPdfGenerator {
     }
     $html = htmlspecialchars_decode(htmlentities($html, ENT_NOQUOTES, 'ISO-8859-1'), ENT_NOQUOTES);
 
-    // $html = str_replace('src="' . $base_url . '/', 'src="/', $html);
-    //    $html = str_replace('href="/', 'href="' . $base_url . '/', $html);.
     $html = str_replace('src="/', 'src="' . $base_url . '/', $html);
     $html = str_replace('&nbsp;', ' ', $html);
 
-    // Echo $base_url;
-    //    echo $html;
-    //    exit();
     $this->dompdf->setOptions($this->options);
     $this->dompdf->loadHtml($html);
     $this->dompdf->setPaper($pageSize, $disposition);

--- a/docroot/modules/custom/dhsc_result_viewer/src/DhscDomPdfGenerator.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/DhscDomPdfGenerator.php
@@ -3,54 +3,13 @@
 namespace Drupal\dhsc_result_viewer;
 
 use Dompdf\Dompdf;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Render\RendererInterface;
 use Drupal\pdf_generator\DomPdfGenerator;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Defines helpers methods to help in managing config which used in SCity.
  */
 class DhscDomPdfGenerator extends DomPdfGenerator {
-
-  /**
-   * The request stack.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
-  protected $requestStack;
-
-  /**
-   * The renderer service.
-   *
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  protected $renderer;
-
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * Constructs a DhscDomPdfGenerator object.
-   *
-   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
-   *   The request stack.
-   * @param \Drupal\Core\Render\RendererInterface $renderer
-   *   The renderer service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
-  public function __construct(RequestStack $request_stack, RendererInterface $renderer, ModuleHandlerInterface $module_handler) {
-    $this->requestStack = $request_stack;
-    $this->renderer = $renderer;
-    $this->moduleHandler = $module_handler;
-    parent::__construct($request_stack, $renderer, $module_handler);
-  }
 
   /**
    * {@inheritdoc}
@@ -68,7 +27,7 @@ class DhscDomPdfGenerator extends DomPdfGenerator {
     // Dompdf needs to be initialized with custom options if they are supplied.
     $this->dompdf = new Dompdf($this->options);
 
-    $css = file_get_contents($this->moduleHandler->getPath('pdf_generator') . '/css/pdf.css');
+    $css = file_get_contents($this->moduleHandler->getModule('pdf_generator')->getPath() . '/css/pdf.css');
 
     // Add inline css from text.
     if (!empty($cssText)) {

--- a/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultEmailForm.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultEmailForm.php
@@ -8,22 +8,19 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Class ResultEmailForm.
  */
-class ResultEmailForm extends FormBase
-{
+class ResultEmailForm extends FormBase {
 
   /**
    * {@inheritdoc}
    */
-  public function getFormId()
-  {
+  public function getFormId() {
     return 'dhsc_result_email_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state)
-  {
+  public function buildForm(array $form, FormStateInterface $form_state) {
     $form['email'] = [
       '#type' => 'email',
       '#title' => $this->t('Input email address'),
@@ -40,7 +37,7 @@ class ResultEmailForm extends FormBase
       '#attributes' => [
         'role' => 'button',
         'aria-label' => $this->t('Send email'),
-        'class' => ['a-button', 'a-button--secondary']
+        'class' => ['a-button', 'a-button--secondary'],
       ],
     ];
     return $form;
@@ -49,11 +46,10 @@ class ResultEmailForm extends FormBase
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state)
-  {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
     $email = $form_state->getValue('email', '');
     $token = \Drupal::request()->query->get('token');
-    $result_summary_type = explode('.' , \Drupal::routeMatch()->getRouteName())[1];
+    $result_summary_type = explode('.', \Drupal::routeMatch()->getRouteName())[1];
 
     $form_state->setRedirect("dhsc_result_viewer." . $result_summary_type . "_email", [
       'email' => $email,
@@ -62,4 +58,5 @@ class ResultEmailForm extends FormBase
 
     return;
   }
+
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultEmailForm.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultEmailForm.php
@@ -5,6 +5,7 @@ namespace Drupal\dhsc_result_viewer\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**

--- a/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultEmailForm.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultEmailForm.php
@@ -4,11 +4,50 @@ namespace Drupal\dhsc_result_viewer\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class ResultEmailForm.
  */
 class ResultEmailForm extends FormBase {
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a ResultEmailForm object.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match service.
+   */
+  public function __construct(RequestStack $request_stack, RouteMatchInterface $route_match) {
+    $this->requestStack = $request_stack;
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('current_route_match')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -48,15 +87,13 @@ class ResultEmailForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $email = $form_state->getValue('email', '');
-    $token = \Drupal::request()->query->get('token');
-    $result_summary_type = explode('.', \Drupal::routeMatch()->getRouteName())[1];
+    $token = $this->requestStack->getCurrentRequest()->query->get('token');
+    $result_summary_type = explode('.', $this->routeMatch->getRouteName())[1];
 
     $form_state->setRedirect("dhsc_result_viewer." . $result_summary_type . "_email", [
       'email' => $email,
       'token' => $token,
     ]);
-
-    return;
   }
 
 }

--- a/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultSummaryForm.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Form/ResultSummaryForm.php
@@ -8,7 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Class ResultSummaryForm.
  */
-class ResultSummaryForm  extends ConfigFormBase {
+class ResultSummaryForm extends ConfigFormBase {
 
   /**
    * Config settings.
@@ -38,7 +38,6 @@ class ResultSummaryForm  extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(static::SETTINGS);
-
 
     $form['self_assessment_settings'] = [
       '#type' => 'details',

--- a/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformHandler/setFormMetdataHandler.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformHandler/setFormMetdataHandler.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  *   submission = \Drupal\webform\Plugin\WebformHandlerInterface::SUBMISSION_REQUIRED,
  * )
  */
-class setFormMetdataHandler extends WebformHandlerBase {
+class SetFormMetdataHandler extends WebformHandlerBase {
 
   /**
    * {@inheritdoc}
@@ -54,13 +54,15 @@ class setFormMetdataHandler extends WebformHandlerBase {
           $submitted_values[] = $item;
         }
       }
-      // If all answers are 'Yes' set tempstore var to show result page variation.
+      // If all answers are 'Yes' set tempstore var to show result page
+      // variation.
       if (!empty($submitted_values) && array_unique($submitted_values) === ['Yes']) {
         $tempstore->set('yes_to_all_questions', TRUE);
       }
     }
 
-    // Set submission id tempstore var to load submission data prior to showing results.
+    // Set submission id tempstore var to load submission data prior to showing
+    // results.
     if ($sid = $webform_submission->id()) {
       $tempstore->set('sid', $sid);
     }

--- a/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentInterface.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentInterface.php
@@ -35,11 +35,10 @@ interface SelfAssessmentInterface {
    */
   public function getSubmissionId();
 
-
   /**
    * Get webform question completion.
    *
-   * @return boolean
+   * @return bool
    *   Return yes_to_all_questions.
    */
   public function questionsAllYes();

--- a/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentInterface.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentInterface.php
@@ -16,8 +16,9 @@ interface SelfAssessmentInterface {
    *   Webform values.
    *
    * @return mixed
+   *   Returns result summary values.
    */
-  public function getResultsSummary($data);
+  public function getResultsSummary(array $data);
 
   /**
    * Get sorts result ids.

--- a/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentResultViewer.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentResultViewer.php
@@ -69,12 +69,14 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The private temp store factory.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     ConfigFactoryInterface $config_factory,
-    PrivateTempStoreFactory $temp_store_factory
+    PrivateTempStoreFactory $temp_store_factory,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->nodeStorage = $entity_type_manager->getStorage('node');
@@ -89,7 +91,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
    * {@inheritdoc}
    */
   public function getCategories() {
-    return $this->taxonomyStorage->loadTree('category', 0, NULL, TRUE);;
+    return $this->taxonomyStorage->loadTree('category', 0, NULL, TRUE);
   }
 
   /**
@@ -138,8 +140,6 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
    *
    * @param array $data
    *   Webform values.
-   * @param bool $top_tips
-   *   Check if top tip.
    *
    * @return array
    *   Return result ids.
@@ -174,12 +174,12 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
    * @param array $data
    *   Webform values.
    *
-   * @return array|int|void
+   * @return int|void
    *   Return result ids.
    */
   protected function getResultId(TermInterface $term, array $data) {
     if ($term->bundle() != 'category') {
-      return;
+      return NULL;
     }
 
     if (!$term->get('field_answer_machine_name')->isEmpty()) {
@@ -193,10 +193,12 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
           ->execute();
       }
 
-      if (isset($result)) {
+      if (!empty($result)) {
         return reset($result);
       }
     }
+
+    return NULL;
   }
 
   /**
@@ -251,8 +253,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
    *   Return webform url.
    */
   protected function getWebFormUrl() {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    if ($submission = $this->getSubmission()) {
+    if ($this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
       $webform = $this->getSubmission()->getWebform();
       if ($webform) {
@@ -268,18 +269,17 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface {
    *   Return webform confirmation page path.
    */
   protected function getConfirmationPagePath() {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    if ($submission = $this->getSubmission()) {
+    if ($this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
       $webform = $this->getSubmission()->getWebform();
       if (!$webform) {
-        return;
+        return NULL;
       }
 
       $config_name = $webform->getConfigDependencyName();
       $config = $this->configFactory->get($config_name);
       if (!$config) {
-        return;
+        return NULL;
       }
       $raw_data = $config->getRawData();
 

--- a/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentResultViewer.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/SelfAssessmentResultViewer.php
@@ -12,8 +12,7 @@ use Drupal\taxonomy\TermInterface;
  *
  * @package Drupal\dhsc_self_assessment_result_viewer
  */
-class SelfAssessmentResultViewer implements SelfAssessmentInterface
-{
+class SelfAssessmentResultViewer implements SelfAssessmentInterface {
 
   /**
    * Entity type manager.
@@ -89,16 +88,14 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
   /**
    * {@inheritdoc}
    */
-  public function getCategories()
-  {
+  public function getCategories() {
     return $this->taxonomyStorage->loadTree('category', 0, NULL, TRUE);;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getResultsSummary($data)
-  {
+  public function getResultsSummary($data) {
     $nids = $this->getResultIds($data);
     if (!$nids) {
       return;
@@ -125,8 +122,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
   /**
    * {@inheritdoc}
    */
-  public function getSortsResultIds()
-  {
+  public function getSortsResultIds() {
     if ($data = $this->getSubmissionData()) {
       $nids = $this->getResultIds($data);
       if (!$nids) {
@@ -148,12 +144,11 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
    * @return array
    *   Return result ids.
    */
-  protected function getResultIds(array $data)
-  {
+  protected function getResultIds(array $data) {
     $categories = $this->getCategories();
     $nids = [];
 
-    /** @var TermInterface $category */
+    /** @var \Drupal\taxonomy\TermInterface $category */
     foreach ($categories as $category) {
       if ($nid = $this->getResultId($category, $data)) {
         $nids[] = $nid;
@@ -174,7 +169,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
   /**
    * Get id of result node.
    *
-   * @param TermInterface $term
+   * @param \Drupal\taxonomy\TermInterface $term
    *   Category term.
    * @param array $data
    *   Webform values.
@@ -182,8 +177,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
    * @return array|int|void
    *   Return result ids.
    */
-  protected function getResultId(TermInterface $term, array $data)
-  {
+  protected function getResultId(TermInterface $term, array $data) {
     if ($term->bundle() != 'category') {
       return;
     }
@@ -208,32 +202,28 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
   /**
    * {@inheritdoc}
    */
-  public function getSubmissionId()
-  {
+  public function getSubmissionId() {
     return $this->tempStore->get('sid');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function questionsAllYes()
-  {
+  public function questionsAllYes() {
     return $this->tempStore->get('yes_to_all_questions');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function questionsAllReset()
-  {
+  public function questionsAllReset() {
     return $this->tempStore->set('yes_to_all_questions', NULL);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getSubmission()
-  {
+  public function getSubmission() {
     $sid = $this->getSubmissionId();
     if ($sid) {
       $submission = $this->entityTypeManager->getStorage('webform_submission')->load($sid);
@@ -241,15 +231,13 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
     }
   }
 
-
   /**
    * Get webform submission data.
    *
    * @return array
    *   Return webform submission data.
    */
-  protected function getSubmissionData()
-  {
+  protected function getSubmissionData() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->getSubmission()) {
       return $submission->getData();
@@ -262,8 +250,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
    * @return \Drupal\Core\GeneratedUrl|string
    *   Return webform url.
    */
-  protected function getWebFormUrl()
-  {
+  protected function getWebFormUrl() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
@@ -280,8 +267,7 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
    * @return mixed|void
    *   Return webform confirmation page path.
    */
-  protected function getConfirmationPagePath()
-  {
+  protected function getConfirmationPagePath() {
     /** @var \Drupal\webform\WebformSubmissionInterface $submission */
     if ($submission = $this->getSubmission()) {
       /** @var \Drupal\webform\WebformInterface $webform */
@@ -300,4 +286,5 @@ class SelfAssessmentResultViewer implements SelfAssessmentInterface
       return $raw_data['settings']['page_confirm_path'];
     }
   }
+
 }

--- a/docroot/modules/custom/dhsc_site/dhsc_site.deploy.php
+++ b/docroot/modules/custom/dhsc_site/dhsc_site.deploy.php
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Contains deployment-related logic.
  */
 
 /**

--- a/docroot/modules/custom/dhsc_site/dhsc_site.deploy.php
+++ b/docroot/modules/custom/dhsc_site/dhsc_site.deploy.php
@@ -1,8 +1,12 @@
 <?php
 
 /**
-* Migrates Section links.
-*/
+ * @file
+ */
+
+/**
+ * Migrates Section links.
+ */
 function dhsc_site_deploy_0001_migrate_section_links() {
 
   $paragraphs = \Drupal::entityTypeManager()
@@ -42,8 +46,7 @@ function dhsc_site_deploy_0001_migrate_section_links() {
 /**
  * Deletes old Section links.
  */
-function dhsc_site_deploy_0002_remove_old_section_links_fields()
-{
+function dhsc_site_deploy_0002_remove_old_section_links_fields() {
   $paragraph_type = 'content_listing_section_links';
   $fields_to_remove = [
     'field_section_link',

--- a/docroot/modules/custom/dhsc_site/dhsc_site.install
+++ b/docroot/modules/custom/dhsc_site/dhsc_site.install
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Contains install related logic.
  */
 
 /**

--- a/docroot/modules/custom/dhsc_site/dhsc_site.install
+++ b/docroot/modules/custom/dhsc_site/dhsc_site.install
@@ -1,7 +1,8 @@
 <?php
 
-use Drupal\node\Entity\Node;
-use Drupal\paragraphs\Entity\Paragraph;
+/**
+ * @file
+ */
 
 /**
  * Implements hook_update_N().

--- a/docroot/modules/custom/dhsc_site/dhsc_site.module
+++ b/docroot/modules/custom/dhsc_site/dhsc_site.module
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Provides custom overrides for the Digital Health and Social Care website.
  */
 
 use Drupal\Core\Entity\EntityInterface;
@@ -107,11 +108,7 @@ function dhsc_site_entity_view_mode_alter(&$view_mode, EntityInterface $entity) 
 }
 
 /**
- * Implements hook_form_alter().
- *
- * @param [type] $form
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- * @param [type] $form_id
+ * Implements hook_form_FORM_ID_alter().
  */
 function dhsc_site_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $displayId = $form_state->get('view')->getDisplay()->display['id'];

--- a/docroot/modules/custom/dhsc_site/dhsc_site.module
+++ b/docroot/modules/custom/dhsc_site/dhsc_site.module
@@ -1,10 +1,14 @@
 <?php
 
+/**
+ * @file
+ */
+
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\Core\Form\FormStateInterface;
 
-/*
+/**
  * Implements hook_theme().
  */
 function dhsc_site_theme() {
@@ -31,28 +35,28 @@ function dhsc_site_theme() {
     ],
     'footer_branding' => [
       'variables' => [
-        'logo' => null,
-        'variant' => null,
-        'site_slogan' => null,
-        'site_name' => null
+        'logo' => NULL,
+        'variant' => NULL,
+        'site_slogan' => NULL,
+        'site_name' => NULL,
       ],
     ],
     'site_copyright' => [
       'variables' => [
-        'text' => null,
+        'text' => NULL,
       ],
     ],
     'footer_contact' => [
       'variables' => [
-        'link' => null,
-        'phone' => null,
+        'link' => NULL,
+        'phone' => NULL,
       ],
     ],
     'related_information' => [
       'variables' => [
-        'title' => null,
+        'title' => NULL,
         'items' => [],
-        'read_more_link' => null,
+        'read_more_link' => NULL,
       ],
     ],
     'skills_active_filters' => [
@@ -80,7 +84,7 @@ function dhsc_site_entity_form_mode_alter(&$form_mode, EntityInterface $entity) 
     || isset($node)
     && $node->getType() === 'skill'
     && $entity->getType() === 'accordion'
-    || $entity->getType() === 'framework_section'){
+    || $entity->getType() === 'framework_section') {
     $form_mode = 'skills_framework';
   }
 }
@@ -88,8 +92,7 @@ function dhsc_site_entity_form_mode_alter(&$form_mode, EntityInterface $entity) 
 /**
  * Implements hook_entity_view_mode_alter().
  */
-function dhsc_site_entity_view_mode_alter(&$view_mode, EntityInterface $entity)
-{
+function dhsc_site_entity_view_mode_alter(&$view_mode, EntityInterface $entity) {
   if (!$entity instanceof ParagraphInterface) {
     return;
   }
@@ -103,11 +106,11 @@ function dhsc_site_entity_view_mode_alter(&$view_mode, EntityInterface $entity)
   }
 }
 
- /**
+/**
  * Implements hook_form_alter().
  *
  * @param [type] $form
- * @param FormStateInterface $form_state
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
  * @param [type] $form_id
  */
 function dhsc_site_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -117,7 +120,7 @@ function dhsc_site_form_views_exposed_form_alter(&$form, FormStateInterface $for
     $form['search']['#attributes']['x-model'] = 'searchInputValue';
     $form['search']['#attributes']['class'][] = 'o-search-page-search-form__submit-button';
 
-    // Reset search input button
+    // Reset search input button.
     $form['search']['#children']['reset'] = [
       '#type' => 'inline_template',
       '#template' => '<button type="button" x-show="searchInputValue !== \'\'" @click="searchInputValue = \'\'" class="o-search-page-search-form__reset-button button">'
@@ -126,7 +129,6 @@ function dhsc_site_form_views_exposed_form_alter(&$form, FormStateInterface $for
     ];
   }
 }
-
 
 /**
  * Implements hook_ENTITY_TYPE_update().

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/FeaturedLinksBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/FeaturedLinksBlock.php
@@ -47,4 +47,5 @@ class FeaturedLinksBlock extends BlockBase {
     }
     return $links;
   }
+
 }

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/FooterBrandingBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/FooterBrandingBlock.php
@@ -3,7 +3,6 @@
 namespace Drupal\dhsc_site\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
 
@@ -44,4 +43,5 @@ class FooterBrandingBlock extends BlockBase {
       '#site_slogan' => $site_slogan,
     ];
   }
+
 }

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/RelatedInformationBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/RelatedInformationBlock.php
@@ -9,7 +9,7 @@ use Drupal\paragraphs\Entity\Paragraph;
 
 /**
  * Provides block with related information
- * when node has the related information field with values
+ * when node has the related information field with values.
  *
  * @Block(
  *   id = "related_information_block",

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/RelatedInformationBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/RelatedInformationBlock.php
@@ -8,6 +8,8 @@ use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
+ * Related information block.
+ *
  * Provides block with related information
  * when node has the related information field with values.
  *

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/SearchFormBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/SearchFormBlock.php
@@ -54,4 +54,5 @@ class SearchFormBlock extends BlockBase {
     }
     return $links;
   }
+
 }

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/SiteCopyrightBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/SiteCopyrightBlock.php
@@ -28,4 +28,5 @@ class SiteCopyrightBlock extends BlockBase {
       '#text' => $copyright,
     ];
   }
+
 }

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/SiteWideAlert.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/SiteWideAlert.php
@@ -15,8 +15,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   category = @Translation("DHSC Site")
  * )
  */
-class SiteWideAlert extends BlockBase
-{
+class SiteWideAlert extends BlockBase {
 
   /**
    * {@inheritdoc}
@@ -58,4 +57,5 @@ class SiteWideAlert extends BlockBase
     // Invalidate cache when the alert text field value is updated.
     Cache::invalidateTags(['alert_text_value']);
   }
+
 }

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Block/SocialMediaLinksBlock.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Block/SocialMediaLinksBlock.php
@@ -45,7 +45,8 @@ class SocialMediaLinksBlock extends BlockBase {
             ];
           }
         }
-      } else {
+      }
+      else {
         $links[] = [
           'url'   => $social_links['uri'],
           'title' => $social_links['title'],

--- a/docroot/themes/custom/dhsc_theme/dhsc_theme.theme
+++ b/docroot/themes/custom/dhsc_theme/dhsc_theme.theme
@@ -14,7 +14,7 @@ use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_preprocess().
- * Adds base path as a variable for Twig templates
+ * Adds base path as a variable for Twig templates.
  */
 function dhsc_theme_preprocess(&$variables, $hook) {
   $variables['base_path'] = base_path();
@@ -31,8 +31,7 @@ function dhsc_theme_preprocess_block(&$variables) {
  * Implements hook_preprocess_HOOK().
  * Build contentback link based on breadcrumb value.
  */
-function dhsc_theme_preprocess_node(&$variables)
-{
+function dhsc_theme_preprocess_node(&$variables) {
 
   $node = $variables['elements']['#node'];
 
@@ -41,7 +40,7 @@ function dhsc_theme_preprocess_node(&$variables)
     [
       'localgov_guides_overview',
       'localgov_guides_page',
-      'landing_page'
+      'landing_page',
     ]
   )) {
     return;
@@ -58,12 +57,13 @@ function dhsc_theme_preprocess_node(&$variables)
   $routeMatch = new RouteMatch($routeName, $route);
   $breadcrumb = Drupal::service('dhsc_site.breadcrumb')->build($routeMatch)->toRenderable();
 
-  // if the breadcrumb contains only one link this must be set to Home.
+  // If the breadcrumb contains only one link this must be set to Home.
   if (count($breadcrumb['#links']) == 1) {
     $variables['link_text'] = $breadcrumb['#links'][0]->getText()->getUntranslatedString();
     $variables['link_alias'] = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
-  } else {
-    // fetch the parent link from the active breadcrumb.
+  }
+  else {
+    // Fetch the parent link from the active breadcrumb.
     $link_item = array_pop($breadcrumb['#links']);
     $variables['link_text'] = $link_item->getText();
     $variables['link_alias'] = $link_item->getUrl()->toString();
@@ -87,7 +87,6 @@ function dhsc_theme_preprocess_region(&$variables) {
     $variables['logo'] = $file_path ?? '';
   }
 }
-
 
 /**
  * Implements hook_preprocess_paragraph__HOOK()
@@ -145,13 +144,13 @@ function dhsc_theme_preprocess_paragraph__pagination(&$variables) {
   if (!empty($previous->uri) && !empty($previous->title)) {
     $links['previous'] = [
       'href' => Url::fromUri($previous->uri)->toString(),
-      'text' => $previous->title
+      'text' => $previous->title,
     ];
   }
   if (!empty($next->uri) && !empty($next->title)) {
     $links['next'] = [
       'href' => Url::fromUri($next->uri)->toString(),
-      'text' => $next->title
+      'text' => $next->title,
     ];
   }
 
@@ -177,10 +176,12 @@ function dhsc_theme_preprocess_paragraph__video(&$variables) {
       $parsedUrl = UrlHelper::parse($url);
       if (isset($parsedUrl['query']) && isset($parsedUrl['query']['v'])) {
         $embed_code = $parsedUrl['query']['v'];
-      } else {
+      }
+      else {
         $embed_code = substr($url, strpos($url, '?v=') + strlen('?v='));
       }
-    } else {
+    }
+    else {
       $embed_code = trim(parse_url($url, PHP_URL_PATH), '/');
     }
 
@@ -220,36 +221,42 @@ function dhsc_theme_preprocess_media_oembed_iframe(&$variables) {
   }
 }
 
-function dhsc_theme_theme_suggestions_details_alter (array &$suggestions, array $variables) {
+/**
+ *
+ */
+function dhsc_theme_theme_suggestions_details_alter(array &$suggestions, array $variables) {
   if ($variables['element'] && isset($variables['element']['#form_id'])) {
     $suggestions[] = 'details__' . str_replace('-', '_', $variables['element']['#form_id']);
   }
 }
 
+/**
+ *
+ */
 function dhsc_theme_theme_suggestions_form_alter(array &$suggestions, array $variables) {
   if ($variables['element']['#form_id'] === 'dhsc_result_email_form') {
     $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#id']);
   }
   $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#form_id']);
 
-  // search form
+  // Search form.
   if (in_array($variables['element']['#id'], ['views-exposed-form-local-search-dhsc-search-page', 'views-exposed-form-acquia-search-dhsc-search-page'])) {
     $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#form_id']) . '__search';
   }
 }
 
 /**
-* Implements hook_theme_suggestions_HOOK_alter().
-*
-* Add views template suggestions.
-*
-* @inheritdoc
-*/
+ * Implements hook_theme_suggestions_HOOK_alter().
+ *
+ * Add views template suggestions.
+ *
+ * @inheritdoc
+ */
 function dhsc_theme_theme_suggestions_views_view_alter(array &$suggestions, array $variables) {
   $suggestions[] = 'views_view__' . $variables['view']->getDisplay()->display['id'];
   $suggestions[] = 'views_view__' . $variables['view']->id();
 
- return $suggestions;
+  return $suggestions;
 }
 
 /**
@@ -269,10 +276,9 @@ function dhsc_theme_theme_suggestions_input_alter(&$suggestions, array $variable
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
  *
- * Add template suggestions for result viewer status messages
+ * Add template suggestions for result viewer status messages.
  */
-function dhsc_theme_theme_suggestions_status_messages_alter(array &$suggestions, array $variables)
-{
+function dhsc_theme_theme_suggestions_status_messages_alter(array &$suggestions, array $variables) {
   $suggestions[] = 'status_messages__dhsc_result_viewer';
 }
 
@@ -287,7 +293,8 @@ function _generate_link_array($link_field_item) {
         'title' => $link_field_item->title ?? 'Link',
         'href' => Url::fromUri($link_field_item->uri)->toString(),
       ];
-    } else {
+    }
+    else {
       $url = Url::fromUri($link_field_item->uri)->toString();
       $path = \Drupal::service('path_alias.manager')->getPathByAlias($url);
       if (preg_match('/node\/(\d+)/', $path, $matches)) {

--- a/docroot/themes/custom/dhsc_theme/dhsc_theme.theme
+++ b/docroot/themes/custom/dhsc_theme/dhsc_theme.theme
@@ -14,6 +14,7 @@ use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_preprocess().
+ *
  * Adds base path as a variable for Twig templates.
  */
 function dhsc_theme_preprocess(&$variables, $hook) {
@@ -22,6 +23,8 @@ function dhsc_theme_preprocess(&$variables, $hook) {
 
 /**
  * Implements hook_preprocess_HOOK().
+ *
+ * Preprocess variables for block templates.
  */
 function dhsc_theme_preprocess_block(&$variables) {
   $variables['site_slogan'] = \Drupal::config('system.site')->get('slogan');
@@ -29,10 +32,10 @@ function dhsc_theme_preprocess_block(&$variables) {
 
 /**
  * Implements hook_preprocess_HOOK().
- * Build contentback link based on breadcrumb value.
+ *
+ * Builds content back link based on breadcrumb value.
  */
 function dhsc_theme_preprocess_node(&$variables) {
-
   $node = $variables['elements']['#node'];
 
   if (!in_array(
@@ -72,9 +75,10 @@ function dhsc_theme_preprocess_node(&$variables) {
 
 /**
  * Implements template_preprocess_region().
+ *
+ * Adds logo variables for the footer region.
  */
 function dhsc_theme_preprocess_region(&$variables) {
-
   if ($variables['region'] == 'footer') {
     $site_settings = \Drupal::service('plugin.manager.site_settings_loader')->getActiveLoaderPlugin();
     $footer_logo_setting = $site_settings->loadByGroup('footer')['footer_secondary_logo'];
@@ -89,7 +93,9 @@ function dhsc_theme_preprocess_region(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_paragraph__HOOK()
+ * Implements hook_preprocess_paragraph__HOOK().
+ *
+ * Preprocesses content listing section.
  */
 function dhsc_theme_preprocess_paragraph__content_listing_section(&$variables) {
   $entity = $variables['paragraph'];
@@ -122,7 +128,9 @@ function dhsc_theme_preprocess_paragraph__content_listing_section(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_paragraph__HOOK()
+ * Implements hook_preprocess_paragraph__HOOK().
+ *
+ * Preprocesses featured items paragraph.
  */
 function dhsc_theme_preprocess_paragraph__featured_items(&$variables) {
   $entity = $variables['paragraph'];
@@ -131,10 +139,11 @@ function dhsc_theme_preprocess_paragraph__featured_items(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_paragraph__HOOK()
+ * Implements hook_preprocess_paragraph__HOOK().
+ *
+ * Preprocesses pagination paragraph.
  */
 function dhsc_theme_preprocess_paragraph__pagination(&$variables) {
-
   $entity = $variables['paragraph'];
   $links = [];
 
@@ -158,7 +167,7 @@ function dhsc_theme_preprocess_paragraph__pagination(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_paragraph__HOOK()
+ * Implements hook_preprocess_paragraph__HOOK().
  */
 function dhsc_theme_preprocess_paragraph__video(&$variables) {
   $paragraph = $variables['paragraph'];
@@ -222,7 +231,7 @@ function dhsc_theme_preprocess_media_oembed_iframe(&$variables) {
 }
 
 /**
- *
+ * Implements hook_theme_suggestions_HOOK_alter().
  */
 function dhsc_theme_theme_suggestions_details_alter(array &$suggestions, array $variables) {
   if ($variables['element'] && isset($variables['element']['#form_id'])) {
@@ -231,7 +240,7 @@ function dhsc_theme_theme_suggestions_details_alter(array &$suggestions, array $
 }
 
 /**
- *
+ * Implements hook_theme_suggestions_HOOK_alter().
  */
 function dhsc_theme_theme_suggestions_form_alter(array &$suggestions, array $variables) {
   if ($variables['element']['#form_id'] === 'dhsc_result_email_form') {


### PR DESCRIPTION
- The `make coding-standards` command runs a PHP code checking utility to ensure that it meets Drupal standards.
- This task involved ensuring the warnings and errors are addressed.