### PR TITLE
Feature/dhscms04 9 create default content for themed report summaries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "drupal/core-composer-scaffold": "^10.3",
         "drupal/core-project-message": "^10.3",
         "drupal/core-recommended": "^10.3",
+        "drupal/default_content": "^2.0@alpha",
         "drupal/devel": "^5.1",
         "drupal/devel_entity_updates": "^4.1",
         "drupal/diff": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90730bd7c59fd16f6e571a6b889ef542",
+    "content-hash": "6c88459480fe21ea81fcb85247fa3bae",
     "packages": [
         {
             "name": "acquia/blt",
@@ -24378,6 +24378,7 @@
         "drupal/advagg": 15,
         "drupal/components": 10,
         "drupal/config_split": 5,
+        "drupal/default_content": 15,
         "drupal/mimemail": 15,
         "drupal/paragraphs_ee": 15,
         "drupal/paragraphs_features": 10,

--- a/config/default/sync/core.entity_form_display.paragraph.results_summary_content.default.yml
+++ b/config/default/sync/core.entity_form_display.paragraph.results_summary_content.default.yml
@@ -1,0 +1,25 @@
+uuid: c70fd00e-fe6d-4c97-89ec-52eab66a5a2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.results_summary_content.field_result_summary
+    - paragraphs.paragraphs_type.results_summary_content
+  module:
+    - text
+id: paragraph.results_summary_content.default
+targetEntityType: paragraph
+bundle: results_summary_content
+mode: default
+content:
+  field_result_summary:
+    type: text_textarea
+    weight: 0
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/sync/core.entity_form_display.taxonomy_term.theme.default.yml
+++ b/config/default/sync/core.entity_form_display.taxonomy_term.theme.default.yml
@@ -1,0 +1,56 @@
+uuid: 8142cfb1-8330-4a4f-9135-4b52db847389
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.theme
+  module:
+    - path
+    - text
+id: taxonomy_term.theme.default
+targetEntityType: taxonomy_term
+bundle: theme
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/default/sync/core.entity_form_display.taxonomy_term.toolkit_theme.default.yml
+++ b/config/default/sync/core.entity_form_display.taxonomy_term.toolkit_theme.default.yml
@@ -1,0 +1,98 @@
+uuid: 83acc0f0-0ac7-4558-b7bb-cf7adcc1e851
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.toolkit_theme.field_result_summary_ref
+    - field.field.taxonomy_term.toolkit_theme.field_theme_title
+    - taxonomy.vocabulary.toolkit_theme
+  module:
+    - field_group
+    - inline_entity_form
+    - paragraphs_ee
+    - paragraphs_features
+third_party_settings:
+  field_group:
+    group_content:
+      children:
+        - name
+        - field_theme_title
+        - group_response_content
+      label: Content
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        direction: horizontal
+        width_breakpoint: 640
+    group_response_content:
+      children:
+        - field_result_summary_ref
+      label: 'Response content'
+      region: content
+      parent_name: group_content
+      weight: 2
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: open
+        description: ''
+        required_fields: false
+id: taxonomy_term.toolkit_theme.default
+targetEntityType: taxonomy_term
+bundle: toolkit_theme
+mode: default
+content:
+  field_result_summary_ref:
+    type: inline_entity_form_simple
+    weight: 26
+    region: content
+    settings:
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      collapsible: false
+      collapsed: false
+      revision: false
+    third_party_settings:
+      paragraphs_features:
+        add_in_between: false
+        add_in_between_link_count: 3
+        delete_confirmation: false
+        show_drag_and_drop: false
+        show_collapse_all: false
+      paragraphs_ee:
+        paragraphs_ee:
+          dialog_off_canvas: false
+          dialog_style: tiles
+  field_theme_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  langcode: true
+  path: true
+  simple_sitemap: true
+  status: true

--- a/config/default/sync/core.entity_view_display.paragraph.results_summary_content.default.yml
+++ b/config/default/sync/core.entity_view_display.paragraph.results_summary_content.default.yml
@@ -1,0 +1,23 @@
+uuid: 14c2fd0a-de69-4f86-926f-f361996697a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.results_summary_content.field_result_summary
+    - paragraphs.paragraphs_type.results_summary_content
+  module:
+    - text
+id: paragraph.results_summary_content.default
+targetEntityType: paragraph
+bundle: results_summary_content
+mode: default
+content:
+  field_result_summary:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/default/sync/core.entity_view_display.taxonomy_term.theme.default.yml
+++ b/config/default/sync/core.entity_view_display.taxonomy_term.theme.default.yml
@@ -1,0 +1,23 @@
+uuid: 47196f8c-84ca-4ee2-9dc9-b1be61b52d44
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.theme
+  module:
+    - text
+id: taxonomy_term.theme.default
+targetEntityType: taxonomy_term
+bundle: theme
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/default/sync/core.entity_view_display.taxonomy_term.toolkit_theme.default.yml
+++ b/config/default/sync/core.entity_view_display.taxonomy_term.toolkit_theme.default.yml
@@ -1,0 +1,43 @@
+uuid: d07114ee-4fb6-4197-a6db-f517e4d8c8ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.toolkit_theme.field_result_summary_ref
+    - field.field.taxonomy_term.toolkit_theme.field_theme_title
+    - taxonomy.vocabulary.toolkit_theme
+  module:
+    - entity_reference_revisions
+    - text
+id: taxonomy_term.toolkit_theme.default
+targetEntityType: taxonomy_term
+bundle: toolkit_theme
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_result_summary_ref:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_theme_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/default/sync/core.extension.yml
+++ b/config/default/sync/core.extension.yml
@@ -27,7 +27,9 @@ module:
   datetime: 0
   datetime_range: 0
   dbal: 0
+  default_content: 0
   dhsc_result_viewer: 0
+  dhsc_result_viewer_default_content: 0
   dhsc_site: 0
   diff: 0
   dynamic_page_cache: 0

--- a/config/default/sync/field.field.paragraph.results_summary_content.field_result_summary.yml
+++ b/config/default/sync/field.field.paragraph.results_summary_content.field_result_summary.yml
@@ -1,0 +1,24 @@
+uuid: d0ebea6b-43e9-4fc7-94bb-30731f22fd94
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_result_summary
+    - filter.format.basic_html
+    - paragraphs.paragraphs_type.results_summary_content
+  module:
+    - text
+id: paragraph.results_summary_content.field_result_summary
+field_name: field_result_summary
+entity_type: paragraph
+bundle: results_summary_content
+label: 'Result summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/default/sync/field.field.taxonomy_term.toolkit_theme.field_result_summary_ref.yml
+++ b/config/default/sync/field.field.taxonomy_term.toolkit_theme.field_result_summary_ref.yml
@@ -1,0 +1,130 @@
+uuid: 2e1d3d06-c7e4-4a82-bccc-6cc994544ad4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_result_summary_ref
+    - paragraphs.paragraphs_type.results_summary_content
+    - taxonomy.vocabulary.toolkit_theme
+  module:
+    - entity_reference_revisions
+id: taxonomy_term.toolkit_theme.field_result_summary_ref
+field_name: field_result_summary_ref
+entity_type: taxonomy_term
+bundle: toolkit_theme
+label: 'Result summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      results_summary_content: results_summary_content
+    negate: 0
+    target_bundles_drag_drop:
+      accordion:
+        weight: 35
+        enabled: false
+      accordion_digital_skills:
+        weight: 36
+        enabled: false
+      accordion_item:
+        weight: 37
+        enabled: false
+      alert:
+        weight: 38
+        enabled: false
+      card_collection:
+        weight: 39
+        enabled: false
+      content_listing:
+        weight: 40
+        enabled: false
+      content_listing_section:
+        weight: 41
+        enabled: false
+      content_listing_section_links:
+        weight: 42
+        enabled: false
+      cta_banner:
+        weight: 43
+        enabled: false
+      dynamic_content_list:
+        weight: 44
+        enabled: false
+      dynamic_content_listing:
+        weight: 45
+        enabled: false
+      featured_items:
+        weight: 46
+        enabled: false
+      framework_row:
+        weight: 47
+        enabled: false
+      framework_section:
+        weight: 48
+        enabled: false
+      from_library:
+        weight: 49
+        enabled: false
+      full_content_listings:
+        weight: 50
+        enabled: false
+      further_information:
+        weight: 51
+        enabled: false
+      latest_events:
+        weight: 52
+        enabled: false
+      latest_news:
+        weight: 53
+        enabled: false
+      link_description:
+        weight: 54
+        enabled: false
+      localgov_image:
+        weight: 55
+        enabled: false
+      localgov_link:
+        weight: 56
+        enabled: false
+      localgov_text:
+        weight: 57
+        enabled: false
+      newsletter_signup:
+        weight: 58
+        enabled: false
+      pagination:
+        weight: 59
+        enabled: false
+      quick_link:
+        weight: 60
+        enabled: false
+      quick_links:
+        weight: 61
+        enabled: false
+      related_information:
+        weight: 62
+        enabled: false
+      results_summary_content:
+        weight: 63
+        enabled: true
+      skills_framework:
+        weight: 64
+        enabled: false
+      topic:
+        weight: 65
+        enabled: false
+      topic_list_builder:
+        weight: 67
+        enabled: false
+      topics:
+        weight: 66
+        enabled: false
+      video:
+        weight: 68
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/default/sync/field.field.taxonomy_term.toolkit_theme.field_theme_title.yml
+++ b/config/default/sync/field.field.taxonomy_term.toolkit_theme.field_theme_title.yml
@@ -1,0 +1,19 @@
+uuid: c47155e8-39c7-4f4f-8e51-b9c1bdfe9733
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_theme_title
+    - taxonomy.vocabulary.toolkit_theme
+id: taxonomy_term.toolkit_theme.field_theme_title
+field_name: field_theme_title
+entity_type: taxonomy_term
+bundle: toolkit_theme
+label: 'Theme title'
+description: 'This title is displayed on the frontend.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/sync/field.storage.paragraph.field_result_summary.yml
+++ b/config/default/sync/field.storage.paragraph.field_result_summary.yml
@@ -1,0 +1,19 @@
+uuid: dff5d769-2aa8-47dd-ba7b-27bf27a15670
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_result_summary
+field_name: field_result_summary
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/sync/field.storage.taxonomy_term.field_result_summary_ref.yml
+++ b/config/default/sync/field.storage.taxonomy_term.field_result_summary_ref.yml
@@ -1,0 +1,21 @@
+uuid: fdc5b425-58d9-4196-b90a-bc4b0179b28f
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+    - taxonomy
+id: taxonomy_term.field_result_summary_ref
+field_name: field_result_summary_ref
+entity_type: taxonomy_term
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 4
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/sync/field.storage.taxonomy_term.field_theme_title.yml
+++ b/config/default/sync/field.storage.taxonomy_term.field_theme_title.yml
@@ -1,0 +1,21 @@
+uuid: 9e280b79-b881-4dc2-8a1d-f86027b1d4d7
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_theme_title
+field_name: field_theme_title
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/sync/language.content_settings.taxonomy_term.toolkit_theme.yml
+++ b/config/default/sync/language.content_settings.taxonomy_term.toolkit_theme.yml
@@ -1,0 +1,11 @@
+uuid: 9bb684d7-fae9-466b-884f-08dc645af757
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.toolkit_theme
+id: taxonomy_term.toolkit_theme
+target_entity_type_id: taxonomy_term
+target_bundle: toolkit_theme
+default_langcode: site_default
+language_alterable: false

--- a/config/default/sync/paragraphs.paragraphs_type.results_summary_content.yml
+++ b/config/default/sync/paragraphs.paragraphs_type.results_summary_content.yml
@@ -1,0 +1,10 @@
+uuid: d3177eac-f017-43f0-a20f-ccca5878c72e
+langcode: en
+status: true
+dependencies: {  }
+id: results_summary_content
+label: 'Results summary content'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/default/sync/rabbit_hole.behavior_settings.taxonomy_vocabulary_toolkit_theme.yml
+++ b/config/default/sync/rabbit_hole.behavior_settings.taxonomy_vocabulary_toolkit_theme.yml
@@ -1,0 +1,14 @@
+uuid: 9d46095a-1d5f-4c31-b875-56ef17ccd5f0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.toolkit_theme
+id: taxonomy_vocabulary_toolkit_theme
+entity_type_id: taxonomy_vocabulary
+entity_id: toolkit_theme
+action: display_page
+allow_override: 1
+redirect: ''
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/default/sync/taxonomy.vocabulary.toolkit_theme.yml
+++ b/config/default/sync/taxonomy.vocabulary.toolkit_theme.yml
@@ -1,0 +1,9 @@
+uuid: f23f40e9-ac85-4643-a778-8516923fd56e
+langcode: en
+status: true
+dependencies: {  }
+name: 'Toolkit theme'
+vid: toolkit_theme
+description: 'Provides categorisation for question content'
+weight: 0
+new_revision: false

--- a/config/default/sync/user.role.localgov_editor.yml
+++ b/config/default/sync/user.role.localgov_editor.yml
@@ -30,6 +30,7 @@ dependencies:
     - taxonomy.vocabulary.skill_level
     - taxonomy.vocabulary.skill_method
     - taxonomy.vocabulary.theme
+    - taxonomy.vocabulary.toolkit_theme
     - workflows.workflow.editorial_workflow
   module:
     - content_moderation
@@ -211,6 +212,7 @@ permissions:
   - 'edit terms in skill_level'
   - 'edit terms in skill_method'
   - 'edit terms in theme'
+  - 'edit terms in toolkit_theme'
   - 'mark as hidden in editoria11y'
   - 'mark as ok in editoria11y'
   - 'revert all revisions'
@@ -256,6 +258,7 @@ permissions:
   - 'view skill revisions'
   - 'view subtopic_page revisions'
   - 'view supplier revisions'
+  - 'view term revisions in toolkit_theme'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
   - 'view unpublished site setting entities'

--- a/config/default/sync/user.role.super_editor.yml
+++ b/config/default/sync/user.role.super_editor.yml
@@ -28,6 +28,7 @@ dependencies:
     - taxonomy.vocabulary.skill_level
     - taxonomy.vocabulary.skill_method
     - taxonomy.vocabulary.theme
+    - taxonomy.vocabulary.toolkit_theme
     - workflows.workflow.editorial_workflow
   module:
     - content_moderation
@@ -205,6 +206,7 @@ permissions:
   - 'edit terms in skill_level'
   - 'edit terms in skill_method'
   - 'edit terms in theme'
+  - 'edit terms in toolkit_theme'
   - 'mark as hidden in editoria11y'
   - 'mark as ok in editoria11y'
   - 'moderated content bulk archive'
@@ -253,6 +255,7 @@ permissions:
   - 'view skill revisions'
   - 'view subtopic_page revisions'
   - 'view supplier revisions'
+  - 'view term revisions in toolkit_theme'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
   - 'view unpublished site setting entities'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/README.md
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/README.md
@@ -1,0 +1,3 @@
+## Overview
+
+The DHSC Result Viewer Default Content module provides default taxonomy content for two DHSC Tools.

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/064ec53b-76e9-4ed9-806c-05309585abd9.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/064ec53b-76e9-4ed9-806c-05309585abd9.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 064ec53b-76e9-4ed9-806c-05309585abd9
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Ethical use of technology'
+  weight:
+    -
+      value: 5
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: b95317ca-6644-478e-b12b-a228b5d67ef7
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457415
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="//beta.digitisingsocialcare.co.uk/digital-skills/theme-6-ethical-use-technology">here</a>.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: f658a323-eec2-43c3-a4f6-574aedd69959
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457415
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-6-ethical-use-technology">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 42be6ca9-0f90-44b5-8c20-a85e18357256
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457415
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 41dd8781-36ab-4cc1-904b-d47bc6cf5636
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457415
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored very high confidence in this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Ethical use of technology'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/07765216-5bb3-4300-950f-147943ab0252.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/07765216-5bb3-4300-950f-147943ab0252.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 07765216-5bb3-4300-950f-147943ab0252
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Technical skills for using technology'
+  weight:
+    -
+      value: 1
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 9959cb34-5781-4180-9897-87cb46ae20fb
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121475
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-2-technical-skills-using-technology">here</a>.&nbsp;<br>&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: c4897324-e2c8-45c2-85d7-f68bdc369a44
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121475
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-2-technical-skills-using-technology">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: fff422ac-4606-4162-bd95-b142047e477e
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121475
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: adbc50c9-f512-46a1-9404-d18f69f21735
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121475
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored very high confidence in this area of knowledge and skills.</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Technical skills for using technology'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/1dedfa29-82b9-4fae-8d08-7e27b4b7fc44.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/1dedfa29-82b9-4fae-8d08-7e27b4b7fc44.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 1dedfa29-82b9-4fae-8d08-7e27b4b7fc44
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Technical skills for using technology'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 09bcac2b-67a1-4813-a6f9-fbdbd3994763
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635524
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-2-technical-skills-using-technology"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 2350777b-6410-43cd-9a7f-47625ea069e2
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635524
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-2-technical-skills-using-technology"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: b4196ef5-3276-47e5-abfe-06fc3ee60fa4
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635524
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 3f9c4757-7f27-436a-b757-d305cf3fa92e
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635524
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Technical skills for using technology'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/258502fb-fad5-4619-aaef-9a3c7dcff08d.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/258502fb-fad5-4619-aaef-9a3c7dcff08d.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 258502fb-fad5-4619-aaef-9a3c7dcff08d
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Communicating through technology'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: f2e8394b-c1b9-4b9d-ad62-8df2d29c54d2
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635582
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-3-communicating-through-technology"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: aeac2e5c-2103-4985-8740-e96f4e5ff022
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635582
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-3-communicating-through-technology"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 297c17a2-9725-4bcd-be10-cd95d386dd5b
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635582
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: d734244f-ba9a-47c5-a17f-927c21f032b1
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635582
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Communicating through technology'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/2b8e074f-0de2-48bc-82ad-3094b9bf61ef.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/2b8e074f-0de2-48bc-82ad-3094b9bf61ef.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 2b8e074f-0de2-48bc-82ad-3094b9bf61ef
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Using technology to support person-centred care'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 608f4594-5eb3-4b9c-bd18-1bf71015e4ab
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635476
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-1-using-technology-support-person-centred-care"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 3f452c89-4652-41bc-afef-ee1a03b02370
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635476
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-1-using-technology-support-person-centred-care"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 6802568e-4ee5-41cb-9a03-33e8e5cfb651
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635476
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: ec3ca3a4-b03b-4d8b-9c6d-6402dea4e0a6
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635476
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Using technology to support person-centred care'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/32e2d5fd-1c1a-4a23-9346-0ef9f4005bee.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/32e2d5fd-1c1a-4a23-9346-0ef9f4005bee.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 32e2d5fd-1c1a-4a23-9346-0ef9f4005bee
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Communicating through technology'
+  weight:
+    -
+      value: 2
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 019e8f8a-3606-417e-8b55-051d28e27b74
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457374
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="//beta.digitisingsocialcare.co.uk/digital-skills/theme-3-communicating-through-technology">here</a>.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: db5e94e4-0848-4fac-9a84-fd8781e9138e
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457374
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking </span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-3-communicating-through-technology"><span>here</span></a><span>.</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 88800d04-95de-45e1-8906-7bd53942def2
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457374
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 6e09df83-8228-4c6a-bac6-1403ea417ef9
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457374
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored very high confidence in this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Communicating through technology'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/46527870-8ddd-4e3b-897f-a37c23ddc1c0.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/46527870-8ddd-4e3b-897f-a37c23ddc1c0.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 46527870-8ddd-4e3b-897f-a37c23ddc1c0
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Using technology to support person-centred care'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: e711c9c4-8040-4b8d-88da-decfcf697fc4
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121444
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-1-using-technology-support-person-centred-care">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: b4423e0f-5bff-4024-8d5d-d65693a16bfd
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121444
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-1-using-technology-support-person-centred-care">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 1d6d482d-63b3-4502-8c5b-cd245ad8544c
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121444
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 97ba98c7-50ae-4e40-98dc-9555494051e3
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737121444
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored very high confidence in this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Using technology to support person-centred care'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/9d5973d7-034e-40c9-86ca-9bad37e80b22.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/9d5973d7-034e-40c9-86ca-9bad37e80b22.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 9d5973d7-034e-40c9-86ca-9bad37e80b22
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Using and managing data'
+  weight:
+    -
+      value: 3
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 47fc1ae7-0170-4e73-9acb-a9d8222f717d
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457397
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-4-using-and-managing-data">here</a>.&nbsp;<br>&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 56863cc4-ca47-46b4-947e-e0eff403ec39
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457397
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-4-using-and-managing-data">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 9024ce14-858b-4d2e-9f3d-78e9ae67dcee
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457397
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 66bfab11-2ecb-4b4b-8f24-ca3d57aa5799
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457397
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p><span>You scored very high confidence in this area of knowledge and skills.</span></p><p><span>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</span></p><p><span>Click here to take our ‘go further’ self-assessment.</span><br>&nbsp;</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Using and managing data'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/9e7f06df-59be-4127-9bd2-afeb39360379.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/9e7f06df-59be-4127-9bd2-afeb39360379.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 9e7f06df-59be-4127-9bd2-afeb39360379
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Digital learning, development and wellbeing'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: d2afba13-cd8f-487c-badf-d5bed1254be9
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635770
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-7-digital-learning-development-and-wellbeing"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: e3526b3d-972a-4509-900d-b27683e745ad
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635770
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-7-digital-learning-development-and-wellbeing"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 7194884e-a311-4a20-b0f9-1a576e4043fa
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635770
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 7a77a963-c76f-4a29-8572-f060440580f0
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635770
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Digital learning, development and wellbeing'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/a8546c0f-51b2-4d54-9775-5046d77c63c4.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/a8546c0f-51b2-4d54-9775-5046d77c63c4.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: a8546c0f-51b2-4d54-9775-5046d77c63c4
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Digital learning, development and wellbeing'
+  weight:
+    -
+      value: 6
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 24f98eda-1605-4a52-9779-95ef8c2c9679
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457422
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-7-digital-learning-development-and-wellbeing">here</a>.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 5cc7ef2a-979d-4eb2-9a92-358529dc42b0
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457422
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-7-digital-learning-development-and-wellbeing">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 4cfd454e-e66b-432a-a9f4-b335d2fd82c2
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457422
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 8548e515-14c7-47b8-8083-3d74306ff638
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457422
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored very high confidence in this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Digital learning, development and wellbeing'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/c46be5ae-1a1f-4ed1-8fcb-6a148c523148.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/c46be5ae-1a1f-4ed1-8fcb-6a148c523148.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: c46be5ae-1a1f-4ed1-8fcb-6a148c523148
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SFA) Being safe and secure online'
+  weight:
+    -
+      value: 4
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: b94c85b2-ac49-4899-b00f-0fcbb6cb258c
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457408
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-5-being-safe-and-secure-online">here</a>.&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 663e7c64-5e79-42a1-8b6f-223f47337b04
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457408
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking <a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-5-being-safe-and-secure-online">here</a>.&nbsp;<br>&nbsp;</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 8181d5c6-e457-4dfc-8d6b-3c299152e03f
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457408
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 55d42003-9269-4bf7-bbf6-0cff0ca47f39
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737457408
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p>You scored very high confidence in this area of knowledge and skills.&nbsp;</p><p>You may wish to take our ‘go further’ digital skills self-assessment reviewing more advanced digital knowledge and skills, including championing and leading digital technology in care.&nbsp;</p><p>Click here to take our ‘go further’ self-assessment.</p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Being safe and secure online'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/cb058a47-a9a8-4ab9-8e3d-d4f50ca9ed8c.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/cb058a47-a9a8-4ab9-8e3d-d4f50ca9ed8c.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: cb058a47-a9a8-4ab9-8e3d-d4f50ca9ed8c
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Using and managing data'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 8b5b12bc-ac69-4dd2-bcd9-10909fdd8bf4
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635634
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-4-using-and-managing-data"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 7d38feb7-0147-4544-9312-f97b9d6b033b
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635634
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-4-using-and-managing-data"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: e2102c2c-5120-459c-911d-1cdd8b6f6101
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635634
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: b9e49e77-8614-44d8-a0ca-10900f1596a5
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635634
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Using and managing data'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/fc2f08fa-36d8-4678-9207-8712f56bf9e0.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/fc2f08fa-36d8-4678-9207-8712f56bf9e0.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: fc2f08fa-36d8-4678-9207-8712f56bf9e0
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Being safe and secure online'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: a2dc072e-fa86-403d-a23c-a6ea1eb8c600
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635674
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-1-using-technology-support-person-centred-care"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: c4f7983c-cbf4-46c4-bbb4-8c93b161cbda
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635674
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-1-using-technology-support-person-centred-care"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: de38f5a0-75c6-478c-a1fb-85fe4aa8da30
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635674
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 3ed4a1af-4279-4ac4-aae7-7c765e8726a6
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635674
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Being safe and secure online'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/ffed0cd1-2ce5-4059-9d7c-b5c643177018.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/content/taxonomy_term/ffed0cd1-2ce5-4059-9d7c-b5c643177018.yml
@@ -1,0 +1,140 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: ffed0cd1-2ce5-4059-9d7c-b5c643177018
+  bundle: toolkit_theme
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '(SGF) Ethical use of technology'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
+  field_result_summary_ref:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 0d137aa8-b412-4275-8361-3a94cfda2e62
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635717
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you were not feeling confident in this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-6-ethical-use-technology"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 87865eee-a773-4022-b797-88ac800da6d1
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635717
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to low confidence around this area of knowledge and skills. You can find practical guidance and resources to support you under this skills theme by clicking&nbsp;</span><a href="https://beta.digitisingsocialcare.co.uk/digital-skills/theme-6-ethical-use-technology"><u>here</u></a><span>.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 47db5fb6-72b0-4011-8ede-bec7fcc17a96
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635717
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored overall that you had mixed to high confidence around this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 377b6953-8e72-4cb0-b646-e463dbd649f9
+          bundle: results_summary_content
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1737635717
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_result_summary:
+            -
+              value: '<p dir="ltr"><span>You scored very high confidence in this area of knowledge and skills.&nbsp;</span></p>'
+              format: basic_html
+  field_theme_title:
+    -
+      value: 'Ethical use of technology'

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/dhsc_result_viewer_default_content.info.yml
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/dhsc_result_viewer_default_content.info.yml
@@ -1,0 +1,23 @@
+name: 'DHSC Result Viewer Default Content'
+type: module
+description: 'Default content required for DHSC Themed Summary Tools.'
+package: DHSC
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:default_content
+default_content:
+  taxonomy_term:
+    - 46527870-8ddd-4e3b-897f-a37c23ddc1c0
+    - 07765216-5bb3-4300-950f-147943ab0252
+    - 32e2d5fd-1c1a-4a23-9346-0ef9f4005bee
+    - 9d5973d7-034e-40c9-86ca-9bad37e80b22
+    - c46be5ae-1a1f-4ed1-8fcb-6a148c523148
+    - 064ec53b-76e9-4ed9-806c-05309585abd9
+    - a8546c0f-51b2-4d54-9775-5046d77c63c4
+    - 2b8e074f-0de2-48bc-82ad-3094b9bf61ef
+    - 1dedfa29-82b9-4fae-8d08-7e27b4b7fc44
+    - 258502fb-fad5-4619-aaef-9a3c7dcff08d
+    - cb058a47-a9a8-4ab9-8e3d-d4f50ca9ed8c
+    - fc2f08fa-36d8-4678-9207-8712f56bf9e0
+    - ffed0cd1-2ce5-4059-9d7c-b5c643177018
+    - 9e7f06df-59be-4127-9bd2-afeb39360379

--- a/docroot/modules/custom/dhsc_result_viewer_default_content/dhsc_result_viewer_default_content.module
+++ b/docroot/modules/custom/dhsc_result_viewer_default_content/dhsc_result_viewer_default_content.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for DHSC Result Viewer Default Content module.
+ */


### PR DESCRIPTION

- feature: (DHSCMS04-9) Install and enable drupal/default_content module.
- feature: (DHSCMS04-9) Custom module to provide default content for the two DSF Tools. Content is provided for specific taxonomy terms, and includes referenced paragraph content.
- feature: (DHSCMS04-9) Config for the taxonomy vocabulary used to create toolkit theme and results summary content. Also includes the paragraph bundle config that this vocabulary references.
- feature: (DHSCMS04-9) Update permissions with relation to the new taxonomy vocabulary.

