### PR TITLE
Bugfix/dhscms04 54 error when changing a reponse

### DIFF
--- a/config/default/acquia/config_split.patch.search_api.index.acquia_search_index.yml
+++ b/config/default/acquia/config_split.patch.search_api.index.acquia_search_index.yml
@@ -1,28 +1,17 @@
 adding:
-  dependencies:
-    config:
-      - search_api.server.acquia_search_server
-    module:
-      - acquia_search
+  status: false
+  third_party_settings:
+    acquia_search:
+      use_edismax: false
+  options:
+    overridden_by_acquia_search: 2
+removing:
+  status: true
   third_party_settings:
     acquia_search:
       use_edismax: 0
-  read_only: false
-  field_settings:
-    status:
-      label: Published
   datasource_settings:
     'entity:node':
       bundles:
         selected:
-          - recommendation
-          - supplier
-  options:
-    overridden_by_acquia_search: 2
-  server: acquia_search_server
-removing:
-  read_only: false
-  field_settings:
-    status:
-      label: status
-  server: null
+          - skill

--- a/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformHandler/setFormMetdataHandler.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformHandler/setFormMetdataHandler.php
@@ -39,7 +39,7 @@ class SetFormMetdataHandler extends WebformHandlerBase {
     $tempstore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
     $submitted_values = [];
 
-    if ($webform->id() === 'self_assessment_tool' || $webform->id() === 'dsf_tool' || $webform->id() === 'dsf_tool_advanced') {
+    if ($webform->id() === 'self_assessment_tool') {
       // Retrieve option values for submitted data.
       foreach ($data as $key => &$item) {
         $element = $webform->getElement($key);
@@ -67,7 +67,7 @@ class SetFormMetdataHandler extends WebformHandlerBase {
       $tempstore->set('sid', $sid);
     }
 
-    if ($update == TRUE) {
+    if ($update == TRUE && ($webform->id() === 'self_assessment_tool' || $webform->id() === 'assured_solutions_tools')) {
       $submission_token = \Drupal::request()->query->get('token');
 
       switch ($webform->id()) {
@@ -77,11 +77,6 @@ class SetFormMetdataHandler extends WebformHandlerBase {
 
         case 'assured_solutions_tools':
           $route_name = 'dhsc_result_viewer.result_summary_assured_solutions';
-          break;
-
-        case 'dsf_tool':
-        case 'dsf_tool_advanced':
-          $route_name = 'dhsc_result_viewer.result_summary_dsf';
           break;
 
         default:


### PR DESCRIPTION
- bugfix: (DHSCMS04-54) Remove hardcoded logic. We're not using a hardcoded approach for the DSF and DSF advanced tools, so this isn't required. Submissions are retrieved via a submission token rather than use of the tempstore for tools using themed summary reports, so the tempstore isn't required either."