### PR TITLE
Feature/dhscms04 38 thematic grouping for webform elements

### DIFF
--- a/config/default/acquia/config_split.patch.search_api.index.acquia_search_index.yml
+++ b/config/default/acquia/config_split.patch.search_api.index.acquia_search_index.yml
@@ -1,17 +1,28 @@
 adding:
-  status: false
-  third_party_settings:
-    acquia_search:
-      use_edismax: false
-  options:
-    overridden_by_acquia_search: 2
-removing:
-  status: true
+  dependencies:
+    config:
+      - search_api.server.acquia_search_server
+    module:
+      - acquia_search
   third_party_settings:
     acquia_search:
       use_edismax: 0
+  read_only: false
+  field_settings:
+    status:
+      label: Published
   datasource_settings:
     'entity:node':
       bundles:
         selected:
-          - skill
+          - recommendation
+          - supplier
+  options:
+    overridden_by_acquia_search: 2
+  server: acquia_search_server
+removing:
+  read_only: false
+  field_settings:
+    status:
+      label: status
+  server: null

--- a/config/default/acquia/config_split.patch.search_api.index.acquia_search_index.yml
+++ b/config/default/acquia/config_split.patch.search_api.index.acquia_search_index.yml
@@ -1,28 +1,17 @@
 adding:
-  dependencies:
-    config:
-      - search_api.server.acquia_search_server
-    module:
-      - acquia_search
+  status: false
+  third_party_settings:
+    acquia_search:
+      use_edismax: false
+  options:
+    overridden_by_acquia_search: 2
+removing:
+  status: true
   third_party_settings:
     acquia_search:
       use_edismax: 0
-  read_only: false
-  field_settings:
-    status:
-      label: Published
   datasource_settings:
     'entity:node':
       bundles:
         selected:
-          - recommendation
-          - supplier
-  options:
-    overridden_by_acquia_search: 2
-  server: acquia_search_server
-removing:
-  read_only: false
-  field_settings:
-    status:
-      label: status
-  server: null
+          - skill

--- a/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformElement/ThemeSelector.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformElement/ThemeSelector.php
@@ -35,14 +35,14 @@ class ThemeSelector extends WebformWizardPage {
     $form = parent::buildConfigurationForm($form, $form_state);
 
     // Get the current selection from form state or saved value.
-    $selected_tid = $form_state->getValue('toolkit_theme') ?? $this->getCurrentTheme($form, $form_state);
+    $selected_term_uuid = $form_state->getValue('toolkit_theme') ?? $this->getCurrentTheme($form, $form_state);
 
     // Add the theme selector dropdown.
     $form['toolkit_theme'] = [
       '#type' => 'select',
       '#title' => $this->t('Select Toolkit Theme'),
       '#options' => $this->getToolkitThemeOptions(),
-      '#default_value' => $selected_tid,
+      '#default_value' => $selected_term_uuid,
       '#empty_option' => $this->t('- Select a Theme -'),
       '#required' => TRUE,
       '#ajax' => [
@@ -59,8 +59,8 @@ class ThemeSelector extends WebformWizardPage {
     ];
 
     // Add the edit link if a theme is selected.
-    if ($selected_tid) {
-      $term = Term::load($selected_tid);
+    if ($selected_term_uuid) {
+      $term = Term::load($selected_term_uuid);
 
       if ($term) {
         $form['theme_edit_link_wrapper']['theme_edit_link'] = [
@@ -85,7 +85,7 @@ class ThemeSelector extends WebformWizardPage {
    */
   public static function updateThemeEditLink(array &$form, FormStateInterface $form_state) {
     // Get the selected taxonomy term ID from the dropdown.
-    $selected_tid = $form_state->getValue('toolkit_theme');
+    $selected_term_uuid = $form_state->getValue('toolkit_theme');
 
     // Initialise the wrapper.
     $edit_link = [
@@ -94,8 +94,8 @@ class ThemeSelector extends WebformWizardPage {
     ];
 
     // If a theme is selected, generate the edit link.
-    if ($selected_tid) {
-      $term = Term::load($selected_tid);
+    if ($selected_term_uuid) {
+      $term = Term::load($selected_term_uuid);
       if ($term) {
         $edit_link['theme_edit_link'] = [
           '#type' => 'link',
@@ -115,14 +115,14 @@ class ThemeSelector extends WebformWizardPage {
   }
 
   /**
-   * Saves the selected taxonomy term (TID) into the Webform's configuration.
+   * Saves the selected taxonomy term (UUID) into the Webform's configuration.
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
 
-    // Get the selected TID.
+    // Get the selected UUID.
     $decorated_form_state = $form_state->getCompleteFormState();
-    $theme_tid = $decorated_form_state->getValue('toolkit_theme');
+    $theme_uuid = $decorated_form_state->getValue('toolkit_theme');
 
     // Get the Webform ID.
     $webform_id = $form_state->getBuildInfo()['args'][0]->id();
@@ -130,12 +130,12 @@ class ThemeSelector extends WebformWizardPage {
     // Get the element key to uniquely identify this instance.
     $element_key = $form_state->getBuildInfo()['args'][1];
 
-    if ($theme_tid) {
+    if ($theme_uuid) {
       // Load existing theme selections or create a new array.
       $theme_settings = $this->webform->getThirdPartySetting('dhsc_result_viewer', 'toolkit_theme', []);
 
-      // Save the TID against the unique element key.
-      $theme_settings[$element_key] = $theme_tid;
+      // Save the UUID against the unique element key.
+      $theme_settings[$element_key] = $theme_uuid;
 
       // Store the updated settings.
       $this->webform->setThirdPartySetting('dhsc_result_viewer', 'toolkit_theme', $theme_settings);
@@ -145,8 +145,8 @@ class ThemeSelector extends WebformWizardPage {
 
       // Debug log.
       \Drupal::logger('dhsc_result_viewer')
-        ->notice('Saved Toolkit Theme TID @tid for element @key in Webform @webform', [
-          '@tid' => $theme_tid,
+        ->notice('Saved Toolkit Theme UUID @uuid for element @key in Webform @webform', [
+          '@uuid' => $theme_uuid,
           '@key' => $element_key,
           '@webform' => $webform_id,
         ]);
@@ -169,8 +169,8 @@ class ThemeSelector extends WebformWizardPage {
 
     // Check if this element has a stored theme.
     if (isset($theme_settings[$element_key])) {
-      $theme_tid = $theme_settings[$element_key];
-      $term = Term::load($theme_tid);
+      $theme_uuid = $theme_settings[$element_key];
+      $term = Term::load($theme_uuid);
 
       if ($term) {
 
@@ -221,7 +221,7 @@ class ThemeSelector extends WebformWizardPage {
       $term = Term::load($term_data->tid);
       if ($term) {
         // Use getName() for multilingual support.
-        $options[$term->id()] = $term->getName();
+        $options[$term->uuid()] = $term->getName();
       }
     }
 


### PR DESCRIPTION
- feature: (DHSCMS04-38) Switch theme selector to use UUID rather than TID to ensure that terms can be provided successfully via default content.