### PR TITLE
Bugfix/dhscms04 56 refactor pdf generation to encode special chars correctly

### DIFF
--- a/docroot/modules/custom/dhsc_result_viewer/css/pdf.css
+++ b/docroot/modules/custom/dhsc_result_viewer/css/pdf.css
@@ -1,0 +1,74 @@
+@media print {
+  header {
+    position: fixed;
+    top: 0;
+  }
+  footer {
+    position: fixed;
+    bottom: 0;
+  }
+}
+
+h1,
+h2,
+h3 {
+  font-family: arial, helvetica, sans-serif;
+}
+
+.results h3,
+h4,
+li,
+strong,
+p {
+  font-family: arial, helvetica, sans-serif;
+}
+
+.report-title {
+  margin-left: 10px;
+}
+
+.results ul li {
+  padding: 5px 0px;
+}
+
+.branding {
+  background-color: #29a189;
+  color: white;
+  font-family: arial, helvetica, sans-serif;
+  font-size: 1.125rem;
+}
+
+.branding td:first-child {
+  width: 70%;
+}
+
+.branding td:nth-child(2) {
+  color: white;
+  font-family: arial, helvetica, sans-serif;
+  font-size: 1.125rem;
+}
+
+.criteria {
+  page-break-after: always;
+}
+
+.logo {
+  height: 3.75rem;
+}
+
+img {
+  height: 2.1rem;
+  width: 7.125rem;
+  padding: 0.75rem;
+}
+
+a {
+  color: #29a189;
+}
+
+.results-summary {
+  margin: 40px 0;
+  border-left: #29a189 solid 3px;
+  padding-left: 20px;
+  page-break-after: always;
+}

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ThemedResultSummaryController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ThemedResultSummaryController.php
@@ -406,7 +406,7 @@ class ThemedResultSummaryController extends ControllerBase {
     ];
 
     // Get the path to the stylesheet.
-    $stylesheet = $this->extensionPathResolver->getPath('module', 'dhsc_result_viewer') . '/css/style.css';
+    $stylesheet = $this->extensionPathResolver->getPath('module', 'dhsc_result_viewer') . '/css/pdf.css';
 
     // Generate the PDF.
     $filename = $webform_title . '-results-' . date('d-M-Y');

--- a/docroot/themes/custom/dhsc_theme/templates/layout/pdf-generator-print.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/layout/pdf-generator-print.html.twig
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="{{ language.language_code|default('en') }}">
 <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style type="text/css">
-    {{ css }}
+    {{ css|raw }}
    </style>
    <title>{{ title }}</title>
 </head>
 <body class="pdf">
-	{{ content }}
+	{{ content|raw }}
 </body>
 </html>

--- a/docroot/themes/custom/dhsc_theme/templates/layout/pdf-generator-print.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/layout/pdf-generator-print.html.twig
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ language.language_code|default('en') }}">
+<head>
+  <style type="text/css">
+    {{ css }}
+   </style>
+   <title>{{ title }}</title>
+</head>
+<body class="pdf">
+	{{ content }}
+</body>
+</html>


### PR DESCRIPTION
- bugfix: (DHSCMS04-56) Previously the source template for the module drupal/pdf_generator was being used to create the markup. This was providing an attribute to set the language to Spanish. We now have our own override template.
- bugfix: (DHSCMS04-56) Update PDF generator template to ensure that CSS and content are not escaped twice.
- bugfix: (DHSCMS04-56) Switch approach used to include CSS and update character encoding technique.
- bugfix: (DHSCMS04-56) Make use of a separate CSS file for PDF generation.