### PR TITLE
Update cache action from v2 to v4

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -80,7 +80,7 @@ jobs:
       run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
     - name: Cache dependencies installed with Composer
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           "${{ env.COMPOSER_CACHE_DIR }}"
@@ -93,7 +93,7 @@ jobs:
         key: os-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
 
     - name: Cache node modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.npm


### PR DESCRIPTION
V2 has been deprecated - see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down