### PR TITLE
Feature/dhscms04 66 edit specific responses after submission

### DIFF
--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
@@ -137,14 +137,6 @@ function dhsc_result_viewer_theme() {
         'webform_id' => [],
       ],
     ],
-    'dhsc_back_button' => [
-      'render element' => 'element',
-      'template' => 'dhsc-back-button',
-    ],
-    'dhsc_save_edit' => [
-      'render element' => 'element',
-      'template' => 'dhsc-save-edit',
-    ],
   ];
 }
 
@@ -199,11 +191,9 @@ function dhsc_result_viewer_form_alter(array &$form, FormStateInterface $form_st
     $form['save_edit'] = [
       '#type' => 'submit',
       '#value' => t('Save edit'),
-      // Allows navigation without validation.
       '#limit_validation_errors' => [],
       '#submit' => ['dhsc_result_viewer_save_edit_submit'],
       '#attributes' => ['class' => ['button', 'a-button', 'a-button--primary'], 'data-twig-suggestion' => 'save-and-edit'],
-      // Ensure it appears before Submit.
       '#theme_wrapper' => 'form_element',
       '#weight' => 10,
     ];
@@ -230,7 +220,8 @@ function dhsc_result_viewer_back_button_submit(&$form, FormStateInterface $form_
   if ($current_step !== null && $current_step > 0) {
     $previous_step = array_keys($all_pages)[$current_step - 1];
   } else {
-    $previous_step = $current_page; // If no valid previous step, stay on the same page.
+    // If no valid previous step, stay on the same page.
+    $previous_step = $current_page;
   }
 
   // Save draft before navigating back.

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
@@ -5,8 +5,12 @@
  * Module to create result pages.
  */
 
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_theme().
@@ -133,20 +137,50 @@ function dhsc_result_viewer_theme() {
         'webform_id' => [],
       ],
     ],
+    'dhsc_back_button' => [
+      'render element' => 'element',
+      'template' => 'dhsc-back-button',
+    ],
+    'dhsc_save_edit' => [
+      'render element' => 'element',
+      'template' => 'dhsc-save-edit',
+    ],
   ];
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_prepare_form().
+ */
+function dhsc_result_viewer_webform_submission_prepare_form(\Drupal\webform\WebformSubmissionInterface $webform_submission, $operation, \Drupal\Core\Form\FormStateInterface $form_state) {
+
+  $current_request = \Drupal::request();
+  $requested_step = (int) $current_request->query->get('edit-page') ?? NULL ;
+
+  // The list of all wizard pages.
+  $all_pages = array_keys($webform_submission->getWebform()->getPages());
+
+  // Ensure the requested step is valid before setting it.
+  if (is_array($all_pages) && isset($all_pages[$requested_step])) {
+    if ($form_state->get('current_page') !== $all_pages[$requested_step ? $requested_step - 1 : 0]) {
+      $form_state->set('current_page', $all_pages[$requested_step ? $requested_step - 1 : 0]);
+    }
+  }
+
+}
+
 
 /**
  * Implements hook_form_alter().
  */
 function dhsc_result_viewer_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
+
   // Re-write submit label when re-submitting answers.
   $form_ids = [
     'webform_submission_assured_solutions_tool_edit_form',
     'webform_submission_self_assessment_tool_edit_form',
     'webform_submission_dsf_tool_edit_form',
     'webform_submission_dsf_tool_advanced_edit_form',
-    'webform_submission_what_good_looks_like_tool_form',
+    'webform_submission_what_good_looks_like_tool_edit_form',
   ];
 
   if (
@@ -154,6 +188,105 @@ function dhsc_result_viewer_form_alter(array &$form, FormStateInterface $form_st
     (string) $form['actions']['submit']['#value'] === 'Save'
   ) {
     $form['actions']['submit']['#value'] = t('Continue');
+  }
+
+  $current_request = \Drupal::request();
+  $requested_step = (int) $current_request->query->get('edit-page');
+
+  // Ensure the requested step is valid before setting it.
+  if ($requested_step > 0) {
+    // Add save edit button.
+    $form['save_edit'] = [
+      '#type' => 'submit',
+      '#value' => t('Save edit'),
+      // Allows navigation without validation.
+      '#limit_validation_errors' => [],
+      '#submit' => ['dhsc_result_viewer_save_edit_submit'],
+      '#attributes' => ['class' => ['button', 'a-button', 'a-button--primary'], 'data-twig-suggestion' => 'save-and-edit'],
+      // Ensure it appears before Submit.
+      '#theme_wrapper' => 'form_element',
+      '#weight' => 10,
+    ];
+    $form['actions']['submit']['#access'] = FALSE;
+    $form['actions']['wizard_next']['#access'] = FALSE;
+  }
+}
+
+/**
+ * Submit handler for the Back button.
+ */
+function dhsc_result_viewer_back_button_submit(&$form, FormStateInterface $form_state) {
+  $current_page = $form_state->get('current_page'); // The key of the current page
+  $all_pages = $form_state->get('pages'); // The list of all wizard pages
+
+  // Ensure $all_pages exists before using array_keys().
+  if (is_array($all_pages)) {
+    $current_step = array_search($current_page, array_keys($all_pages), true);
+  } else {
+    $current_step = null;
+  }
+
+  // Determine the previous step.
+  if ($current_step !== null && $current_step > 0) {
+    $previous_step = array_keys($all_pages)[$current_step - 1];
+  } else {
+    $previous_step = $current_page; // If no valid previous step, stay on the same page.
+  }
+
+  // Save draft before navigating back.
+  $submission = $form_state->getFormObject()->getEntity();
+  if ($submission instanceof WebformSubmissionInterface) {
+    $submission->set('in_draft', TRUE);
+    $submission->save();
+  }
+
+  // Move the wizard back.
+  $form_state->set('current_page', $previous_step);
+  $form_state->setRebuild();
+
+  // Always return an AJAX response.
+  $response = new AjaxResponse();
+
+  // Rebuild the form.
+  $form = \Drupal::formBuilder()->rebuildForm($form_state->getBuildInfo()['form_id'], $form_state);
+
+  // Ensure the correct wrapper ID for Webform wizard replacement.
+  $wrapper_id = $form['#id'] ?? 'webform-ajax-wrapper';
+
+  // Replace only the Webform wizard section.
+  $response->addCommand(new ReplaceCommand("#{$wrapper_id}", \Drupal::service('renderer')->render($form)));
+
+  return $response;
+}
+
+/**
+ * Submit handler for the Back button.
+ */
+function dhsc_result_viewer_save_edit_submit(&$form, FormStateInterface $form_state) {
+
+  // Save draft before navigating back.
+  $submission = $form_state->getFormObject()->getEntity();
+  if ($submission instanceof WebformSubmissionInterface) {
+    $submission->set('in_draft', FALSE);
+    $submission->save();
+
+    $token = $submission->get('token')->getValue();
+
+    $current_page = $form_state->get('current_page');
+    $all_pages = array_keys($submission->getWebform()->getPages());
+    $current_step = array_search($current_page, $all_pages) + 1;
+
+    // Generate the redirect URL with webform ID and token.
+    $webform_id = $submission->getWebform()->id();
+    $redirect_url = Url::fromRoute(
+      'dhsc_result_viewer.themed_result_summary',
+      ['webform_id' => $webform_id, 'token' => $token[0]['value']],
+      ['absolute' => TRUE,
+      'fragment' => 'response-' . $current_step],
+    )->toString();
+
+    // Set redirect.
+    $form_state->setRedirectUrl(Url::fromUri($redirect_url));
   }
 }
 
@@ -208,7 +341,7 @@ function dhsc_result_viewer_webform_submission_form_alter(array &$form, FormStat
     'dsf_tool',
     'dsf_tool_advanced',
     'what_good_looks_like_tool',
-  ]) && ($current_page = $form_state->get('current_page')) !== '') {
+  ]) && ($current_page = $form_state->get('current_page') !== '')) {
     // Add a hidden form element to track the current step.
     $form['current_step'] = [
       '#type' => 'value',
@@ -224,12 +357,23 @@ function dhsc_result_viewer_theme_suggestions_webform_submission_form_alter(arra
   if (in_array($variables['form']['#webform_id'], [
     'self_assessment_tool',
     'assured_solutions_tool',
-    'dsf_tool',
-    'dsf_tool_advanced',
-    'what_good_looks_like_tool',
   ])) {
     $suggestions[] = 'webform_submission_form' . '__dhsc_tool__step';
     $suggestions[] = 'webform_submission_form' . '__dhsc_tool__' . $variables['form']['current_step']['#value'];
+  }
+  else {
+    $suggestions[] = 'webform_submission_form' . '__dhsc_tool__step';
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function dhsc_result_viewer_theme_suggestions_input_alter(&$suggestions, array $variables) {
+  $element = $variables['element'];
+  if (isset($element['#attributes']['data-twig-suggestion'])) {
+    $suggestion_suffix = str_replace(['-'], '_', $element['#attributes']['data-twig-suggestion']);
+    $suggestions[] = 'input__' . $element['#type'] . '__' . $suggestion_suffix;
   }
 }
 
@@ -291,34 +435,6 @@ function dhsc_result_viewer_preprocess_assured_solutions_tool__step_1(&$variable
 
   // Pass url from config for back behaviour.
   $variables['link'] = Url::fromUserInput($landing_page_uri, ['absolute' => TRUE]);
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function dhsc_result_viewer_preprocess_dsf_tool__step_1(&$variables) {
-  // Get tool landing page uri from config.
-  $config = \Drupal::config('dhsc_result_viewer.result_summary_settings');
-  $landing_page_uri = $config->get('dsf_landing_page');
-
-  // Pass url from config for back behaviour.
-  if ($landing_page_uri) {
-    $variables['link'] = Url::fromUserInput($landing_page_uri, ['absolute' => TRUE]);
-  }
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function dhsc_result_viewer_preprocess_dsf_tool_advanced__step_1(&$variables) {
-  // Get tool landing page uri from config.
-  $config = \Drupal::config('dhsc_result_viewer.result_summary_settings');
-  $landing_page_uri = $config->get('dsf_advanced_landing_page');
-
-  // Pass url from config for back behaviour.
-  if ($landing_page_uri) {
-    $variables['link'] = Url::fromUserInput($landing_page_uri, ['absolute' => TRUE]);
-  }
 }
 
 /**

--- a/docroot/modules/custom/dhsc_result_viewer/src/Controller/ThemedResultSummaryController.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Controller/ThemedResultSummaryController.php
@@ -254,6 +254,7 @@ class ThemedResultSummaryController extends ControllerBase {
         // and 4.
         $scores_by_theme = $this->resultViewer->getThemeScores($webform, $sorted_results);
 
+        $step_number = 1;
         // Process results content based on derived theme data.
         foreach ($scores_by_theme as $uuid => $theme_score) {
           // Reset response array.
@@ -274,7 +275,6 @@ class ThemedResultSummaryController extends ControllerBase {
           // While not needed for this project, a future enhancement could
           // refine this logic for better adaptability.
           $quartile = match (TRUE) {
-
             // Normalise the score into quartile levels.
             $theme_score['score'] >= 1 && $theme_score['score'] < 1.75 => 'QA',
             $theme_score['score'] >= 1.75 && $theme_score['score'] < 2.5 => 'QB',
@@ -317,10 +317,25 @@ class ThemedResultSummaryController extends ControllerBase {
 
           $theme_name = $theme ? $theme->get('field_theme_title')->value : 'Unassigned Theme';
 
+          // Construct submission URL which is used to re-edit responses post
+          // submission.
+          $webform_url = Url::fromRoute('entity.webform.canonical', ['webform' => $webform->id()])
+            ->toString();
+          $submission_url = Url::fromUserInput($webform_url, ['query' => ['token' => $submission_token]])
+            ->toString();
+
+          // Assign step number to each response.
+          // This is needed to build the edit response link.
+          foreach ($responses as $key => $response) {
+            $responses[$key]['step_number'] = $step_number;
+            $step_number++;
+          }
+
           $elements[] = [
             '#theme' => 'dhsc_themed_results_list',
             '#title' => $theme_name,
             '#summary' => $config->get('dsf_result_summary') ? $config->get('dsf_result_summary') : NULL,
+            '#submission_url' => $submission_url,
             '#responses' => $responses,
             '#result' => $result,
             '#webform_id' => $webform_id,

--- a/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformElement/ThemeSelector.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Plugin/WebformElement/ThemeSelector.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\dhsc_result_viewer\Plugin\WebformElement;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Plugin\WebformElement\WebformWizardPage;
+use Drupal\webform\WebformSubmissionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -229,6 +229,44 @@ class ThemeSelector extends WebformWizardPage {
           '#weight' => -10,
         ];
       }
+    }
+
+    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
+    $submission = $element['#webform_submission'];
+
+    if ($submission instanceof WebformSubmissionInterface) {
+      $submission->set('in_draft', TRUE);
+      $submission->save();
+      \Drupal::logger('dhsc_result_viewer')
+        ->notice('Auto-saved draft for Webform submission ID @id.', ['@id' => $submission->id()]);
+    }
+
+    // Add back button.
+    $element['back'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Back'),
+      '#limit_validation_errors' => [],
+      '#submit' => ['dhsc_result_viewer_back_button_submit'],
+      '#attributes' => ['class' => ['button', 'button--primary'], 'data-twig-suggestion' => 'previous'],
+      '#theme_wrapper' => ['form_element'],
+      '#weight' => -10,
+    ];
+
+    parent::showPage($element);
+
+  }
+
+  /**
+   * Saves the webform submission as a draft.
+   */
+  protected function saveDraft(FormStateInterface $form_state) {
+    $submission = $form_state->getFormObject()->getEntity();
+    if ($submission instanceof WebformSubmissionInterface) {
+      $submission->set('in_draft', TRUE);
+      $submission->save();
+
+      \Drupal::logger('dhsc_result_viewer')
+        ->notice('Auto-saved draft for Webform submission ID @id.', ['@id' => $submission->id()]);
     }
   }
 

--- a/docroot/modules/custom/dhsc_result_viewer/src/ThemedResultViewer.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/ThemedResultViewer.php
@@ -402,6 +402,8 @@ class ThemedResultViewer implements ThemedResultViewerInterface {
    *
    * @return array
    *   Array containing all details of the message.
+   *
+   * @throws \Exception
    */
   public function buildEmail($email, array $results, string $webform_title, string $webform_id) {
     $module = 'dhsc_result_viewer';

--- a/docroot/themes/custom/dhsc_theme/templates/form/input--submit--save-and-edit.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/form/input--submit--save-and-edit.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+<input{{ attributes }} />{{ children }}

--- a/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-themed-results-list--dsf-tool-advanced.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-themed-results-list--dsf-tool-advanced.html.twig
@@ -48,10 +48,15 @@ Variables available:
     {% if responses %}
       <div class="o-tool__summary text-sm tablet:text-md mb-2">
         {% for response in responses %}
-
-          <h3 class="font-bold text-md mb-4 leading-[30px]">{{ response.processed_text_2['#text']|striptags }}</h3>
+          <h3 id="{{ 'response-' ~ response.step_number }}" class="font-bold text-md mb-4 leading-[30px]">{{ response.processed_text_2['#text']|striptags }}</h3>
 
           <p class="font-normal text-sm mb-4">Your response: <span class="font-bold">{{ response.response_text }}</span></p>
+
+          {% if submission_url %}
+            <p class="font-normal text-sm mb-20 print:hidden">
+              <a href="{{ submission_url ~ '&edit-page=' ~ response.step_number }}">{{ 'Change my response'|t }}</a>
+            </p>
+          {% endif %}
         {% endfor %}
       </div>
     {% endif %}

--- a/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-themed-results-list--dsf-tool.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-themed-results-list--dsf-tool.html.twig
@@ -49,9 +49,16 @@ Variables available:
       <div class="o-tool__summary text-sm tablet:text-md mb-2">
         {% for response in responses %}
 
-          <h3 class="font-bold text-md mb-4 leading-[30px]">{{ response.processed_text_2['#text']|striptags }}</h3>
+          <h3 id="{{ 'response-' ~ response.step_number }}" class="font-bold text-md mb-4 leading-[30px]">{{ response.processed_text_2['#text']|striptags }}</h3>
 
           <p class="font-normal text-sm mb-4">Your response: <span class="font-bold">{{ response.response_text }}</span></p>
+
+          {% if submission_url %}
+            <p class="font-normal text-sm mb-20 print:hidden">
+              <a href="{{ submission_url ~ '&edit-page=' ~ response.step_number }}">{{ 'Change my response'|t }}</a>
+            </p>
+          {% endif %}
+
         {% endfor %}
       </div>
     {% endif %}

--- a/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-themed-results-list--what-good-looks-like-tool.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-themed-results-list--what-good-looks-like-tool.html.twig
@@ -49,11 +49,18 @@ Variables available:
       <div class="o-tool__summary text-sm tablet:text-md mb-2">
         {% for response in responses %}
 
-          <h3 class="font-bold text-md mb-3 leading-[30px]">{{ response.processed_text_2['#text']|striptags }}</h3>
+          <h3 id="{{ 'response-' ~ response.step_number }}" class="font-bold text-md mb-3 leading-[30px]">{{ response.processed_text_2['#text']|striptags }}</h3>
           <div class="prose max-w-full">{{ response.processed_text_3 }}</div>
 
           <h4 class="font-bold text-md mt-4 mb-3 leading-[30px]">You rated your organisation</h4>
           <p class="font-normal text-sm mb-6">{{ response.response_text }}</p>
+
+          {% if submission_url %}
+            <p class="font-normal text-sm mb-20 print:hidden">
+              <a href="{{ submission_url ~ '&edit-page=' ~ response.step_number }}">{{ 'Change my response'|t }}</a>
+            </p>
+          {% endif %}
+
         {% endfor %}
       </div>
     {% endif %}

--- a/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-tool--themed-results-summary--dsf-tool-advanced.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-tool--themed-results-summary--dsf-tool-advanced.html.twig
@@ -25,12 +25,6 @@ Variables available:
 
   {{ result_summary }}
 
-  {% if submission_url %}
-    <div class="o-tool__actions mb-20 print:hidden">
-      <a href="{{ submission_url }}">{{ 'Change my responses'|t }}</a>
-    </div>
-  {% endif %}
-
   {% if result_summary %}
     <div x-data class="mb-7 pb-7">
       <a class="a-button a-button--primary tablet:mb-0 tablet:mr-5" href="{{ download_results_path }}">

--- a/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-tool--themed-results-summary--dsf-tool.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-tool--themed-results-summary--dsf-tool.html.twig
@@ -25,12 +25,6 @@ Variables available:
 
   {{ result_summary }}
 
-  {% if submission_url %}
-    <div class="o-tool__actions mb-20 print:hidden">
-      <a href="{{ submission_url }}">{{ 'Change my responses'|t }}</a>
-    </div>
-  {% endif %}
-
   {% if result_summary %}
     <div x-data class="mb-7 pb-7">
       <a class="a-button a-button--primary tablet:mb-0 tablet:mr-5" href="{{ download_results_path }}">

--- a/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-tool--themed-results-summary--what-good-looks-like-tool.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/tools/dhsc-tool--themed-results-summary--what-good-looks-like-tool.html.twig
@@ -26,12 +26,6 @@ Variables available:
 
   {{ result_summary }}
 
-  {% if submission_url %}
-    <div class="o-tool__actions mb-20 print:hidden">
-      <a href="{{ submission_url }}">{{ 'Change my responses'|t }}</a>
-    </div>
-  {% endif %}
-
   {% if result_summary %}
     <div x-data class="mb-7 pb-7">
       <a class="a-button a-button--primary tablet:mb-0 tablet:mr-5" href="{{ download_results_path }}">


### PR DESCRIPTION
- feature: (DHSCMS04-66) Update to provide a response-specific edit link within the report summary.
- feature: (DHSCMS04-66) Update phpdoc comment.
- feature: (DHSCMS04-66) Provide a back button via the webform element to provide a more robust solution. Ensure that draft mode is used and that the submission is saved at each wizard step.
- feature: (DHSCMS04-66) Provide the global step number within the response array so it can be used to construct URL fragments and parameters. Ensure the submission URL is provided for each response block.
- feature: (DHSCMS04-66) Improve webform submission handling, add AJAX back/save edit actions, enhance navigation, update URL fragments, fix form ID reference, and remove redundant preprocess functions.
- feature: (DHSCMS04-66) Remove previous edit response link from the main reports.
- feature: (DHSCMS04-66) Provide a template for the save and edit button.