### PR TITLE
Feature/dhscms04 74 webform wizard refresh persistence

### DIFF
--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
@@ -5,13 +5,14 @@
  * Module to create result pages.
  */
 
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\WebformSubmissionInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\dhsc_result_viewer\Constants\WebformToolConstants;
 
 /**
  * Implements hook_theme().
@@ -44,7 +45,20 @@ function dhsc_result_viewer_theme() {
         'email_form' => NULL,
       ],
     ],
-    'dhsc_themed_results_list' => [
+    'dhsc_themed_response_list' => [
+      'variables' => [
+        'title' => NULL,
+        'summary' => NULL,
+        'result_variant' => NULL,
+        'submission_url' => NULL,
+        'responses' => NULL,
+        'result' => NULL,
+        'no_result' => NULL,
+        'email_form' => NULL,
+        'webform_id' => NULL,
+      ],
+    ],
+    'dhsc_themed_recommendation_item' => [
       'variables' => [
         'title' => NULL,
         'summary' => NULL,
@@ -127,7 +141,17 @@ function dhsc_result_viewer_theme() {
       ],
       'template' => 'toolkit-theme-selector',
     ],
-    'dhsc_tool__themed_results_summary' => [
+    'dhsc_tool__themed_response_summary' => [
+      'variables' => [
+        'title' => NULL,
+        'result_summary' => [],
+        'submission_url' => NULL,
+        'webform_id' => NULL,
+        'token' => NULL,
+        'previous_page_url' => NULL,
+      ],
+    ],
+    'dhsc_tool__themed_recommendation_summary' => [
       'variables' => [
         'title' => NULL,
         'result_summary' => [],
@@ -135,7 +159,8 @@ function dhsc_result_viewer_theme() {
         'download_results_path' => NULL,
         'email_form' => [],
         'manager_email_form' => [],
-        'webform_id' => [],
+        'webform_id' => NULL,
+        'token' => NULL,
       ],
     ],
   ];
@@ -145,16 +170,32 @@ function dhsc_result_viewer_theme() {
  * Implements hook_ENTITY_TYPE_prepare_form().
  */
 function dhsc_result_viewer_webform_submission_prepare_form(\Drupal\webform\WebformSubmissionInterface $webform_submission, $operation, \Drupal\Core\Form\FormStateInterface $form_state) {
-  $current_request = \Drupal::request();
-  $requested_step = (int) $current_request->query->get('edit-page') ?? NULL;
+  $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+  $webform_id = $webform_submission->getWebform()->id();
+  if ($webform_tool_service->isThemedTool($webform_id)) {
+    // We need to ensure that users can go back to edit questions from the
+    // response summary page. This is carried out via an 'edit-page' query
+    // parameter.
+    $current_request = \Drupal::request();
 
-  // The list of all wizard pages.
-  $all_pages = array_keys($webform_submission->getWebform()->getPages());
+    // The list of all wizard pages.
+    $all_pages = array_keys($webform_submission->getWebform()->getPages());
 
-  // Ensure the requested step is valid before setting it.
-  if (is_array($all_pages) && isset($all_pages[$requested_step])) {
-    if ($form_state->get('current_page') !== $all_pages[$requested_step ? $requested_step - 1 : 0]) {
-      $form_state->set('current_page', $all_pages[$requested_step ? $requested_step - 1 : 0]);
+    $requested_step = (int) ($current_request->query->get('edit-page') ?? $current_request->query->get('page'));
+
+    if (!$requested_step) {
+      $requested_step = dhsc_result_viewer_get_webform_tool_service()->getStepValue($webform_id);
+    }
+
+    // If a page has been specified via a URL parameter or via tempstore we will
+    // use this to set the current page.
+    if ($requested_step) {
+      // Ensure the requested step is valid before setting it.
+      if (is_array($all_pages) && isset($all_pages[$requested_step])) {
+        if ($form_state->get('current_page') !== $all_pages[$requested_step ? $requested_step - 1 : 0]) {
+          $form_state->set('current_page', $all_pages[$requested_step ? $requested_step - 1 : 0]);
+        }
+      }
     }
   }
 }
@@ -163,44 +204,61 @@ function dhsc_result_viewer_webform_submission_prepare_form(\Drupal\webform\Webf
  * Implements hook_form_alter().
  */
 function dhsc_result_viewer_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
-  // Re-write submit label when re-submitting answers.
-  $form_ids = [
-    'webform_submission_assured_solutions_tool_edit_form',
-    'webform_submission_self_assessment_tool_edit_form',
-    'webform_submission_dsf_tool_edit_form',
-    'webform_submission_dsf_tool_advanced_edit_form',
-    'webform_submission_what_good_looks_like_tool_edit_form',
-  ];
+  $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+  if ($webform_tool_service->isToolSubmissionForm($form_id)) {
+    // Re-write submit label when re-submitting answers.
+    if ((string) $form['actions']['submit']['#value'] === 'Save') {
+      $form['actions']['submit']['#value'] = t('Continue');
+    }
 
-  if (
-    in_array($form_id, $form_ids) &&
-    (string) $form['actions']['submit']['#value'] === 'Save'
-  ) {
-    $form['actions']['submit']['#value'] = t('Continue');
+    // Auto-save progress on wizard step navigation.
+    if (isset($form['actions']['wizard_next'])) {
+      array_unshift($form['actions']['wizard_next']['#submit'], 'dhsc_result_viewer_store_draft_submission');
+    }
   }
 
-  $current_request = \Drupal::request();
-  $requested_step = (int) $current_request->query->get('edit-page') ?? NULL;
+  if ($webform_tool_service->isThemedToolSubmissionForm($form_id)) {
+    // If the form is in 'edit mode' and the user is going back to edit the form
+    // make sure a 'save edit' button is available.
+    $current_request = \Drupal::request();
+    $requested_step = (int) $current_request->query->get('edit-page') ?? NULL;
 
-  // Ensure the requested step is valid before setting it.
-  if ($requested_step > 0) {
-    // Add save edit button.
-    $form['save_edit'] = [
-      '#type' => 'submit',
-      '#value' => t('Continue'),
-      '#limit_validation_errors' => [],
-      '#submit' => ['dhsc_result_viewer_save_edit_submit'],
-      '#attributes' => [
-        'class' => ['button', 'a-button', 'a-button--primary'],
-        'data-twig-suggestion' => 'save-and-edit',
-      ],
-      '#theme_wrapper' => 'form_element',
-      '#weight' => 10,
-    ];
-    $form['actions']['submit']['#access'] = FALSE;
-    $form['actions']['wizard_next']['#access'] = FALSE;
+    // Ensure the requested step is valid before setting it.
+    if ($requested_step > 0) {
+      // Add save edit button.
+      $form['save_edit'] = [
+        '#type' => 'submit',
+        '#value' => t('Continue'),
+        '#limit_validation_errors' => [],
+        '#submit' => ['dhsc_result_viewer_save_edit_submit'],
+        '#attributes' => [
+          'class' => ['button', 'a-button', 'a-button--primary'],
+          'data-twig-suggestion' => 'save-and-edit',
+        ],
+        '#theme_wrapper' => 'form_element',
+        '#weight' => 10,
+      ];
+      $form['actions']['submit']['#access'] = FALSE;
+      $form['actions']['wizard_next']['#access'] = FALSE;
+    }
   }
 }
+
+///**
+// * AJAX callback to auto-save submission data.
+// *
+// * @throws \Drupal\Core\Entity\EntityStorageException
+// */
+//function dhsc_result_viewer_save_submission_progress(array &$form, FormStateInterface $form_state) {
+//  $submission_id = $form_state->getValue('submission_id');
+//  if ($submission_id) {
+//    $data = $form_state->getValues();
+//    $submission = WebformSubmission::load($submission_id);
+//    $submission->setData($data);
+//    $submission->save();
+//  }
+//  return $form;
+//}
 
 /**
  * Submit handler for the Back button.
@@ -209,22 +267,26 @@ function dhsc_result_viewer_back_button_submit(&$form, FormStateInterface $form_
   $webform_id = $form['#webform_id'];
   $submission = $form_state->getFormObject()->getEntity();
   $token = $submission->get('token')->getValue()[0]['value'] ?? '';
-  $requested_step = getRequestedStep();
+
+  $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+  $requested_step = $webform_tool_service->getRequestedStep();
 
   if ($requested_step && $requested_step > 0) {
     // Re-edit mode.
     // Redirect to previous response step.
-    performRedirect(getSummaryUrl($webform_id, $token, $requested_step));
+    $summary_url = $webform_tool_service->getSummaryUrl($webform_id, $token, $requested_step);
+    $webform_tool_service->performRedirect($summary_url);
+    // .. ends with redirect.
   }
   else {
     // Wizard navigation treatment.
     // Go to the previous step or landing page.
-    $previous_step = getPreviousStep($form_state);
+    $previous_step = $webform_tool_service->getPreviousStep($form_state);
 
     if ($previous_step === NULL) {
       // Redirect back to the landing page associated with tool.
-      $landing_page_url = getLandingPageUrl($webform_id);
-      performRedirect($landing_page_url);
+      $landing_page_url = $webform_tool_service->getLandingPageUrl($webform_id);
+      $webform_tool_service->performRedirect($landing_page_url);
     }
 
     // Save draft before navigating back.
@@ -237,75 +299,8 @@ function dhsc_result_viewer_back_button_submit(&$form, FormStateInterface $form_
     $form_state->set('current_page', $previous_step);
     $form_state->setRebuild();
 
-    return rebuildWebformAjax($form, $form_state);
+    return $webform_tool_service->rebuildWebformAjax($form, $form_state);
   }
-}
-
-/**
- * Get the requested step from the current request.
- */
-function getRequestedStep() {
-  return \Drupal::request()->query->get('edit-page');
-}
-
-/**
- * Generate the summary URL for re-edit mode.
- */
-function getSummaryUrl(string $webform_id, $token, int $requested_step): string {
-
-  return Url::fromRoute(
-    'dhsc_result_viewer.themed_result_summary',
-    ['webform_id' => $webform_id, 'token' => $token],
-    ['absolute' => TRUE, 'fragment' => 'response-' . $requested_step]
-  )->toString();
-}
-
-/**
- * Get the previous step in the wizard.
- */
-function getPreviousStep(FormStateInterface $form_state): ?string {
-  // Get the current step by obtaining the array key.
-  $current_page = $form_state->get('current_page');
-  $all_pages = $form_state->get('pages');
-
-  // Increment by one to provide the current step number
-  $current_step = array_search($current_page, array_keys($all_pages), TRUE) + 1;
-  $previous_step = $current_step - 1;
-
-  return ($current_step > 1) ? array_keys($all_pages)[$previous_step - 1] : NULL;
-}
-
-/**
- * Get the landing page URL or fallback to front page.
- */
-function getLandingPageUrl(string $webform_id): string {
-  $landing_page_path = getLandingPagePath($webform_id);
-
-  return $landing_page_path
-    ? Url::fromUserInput($landing_page_path, ['absolute' => TRUE])->toString()
-    : Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
-}
-
-/**
- * Perform a redirect response and exit.
- */
-function performRedirect(string $url): void {
-  $response = new RedirectResponse($url);
-  $response->send();
-  exit();
-}
-
-/**
- * Rebuild the webform via AJAX.
- */
-function rebuildWebformAjax(array &$form, FormStateInterface $form_state): AjaxResponse {
-  $response = new AjaxResponse();
-  $form = \Drupal::formBuilder()->rebuildForm($form_state->getBuildInfo()['form_id'], $form_state);
-  $wrapper_id = $form['#id'] ?? 'webform-ajax-wrapper';
-
-  $response->addCommand(new ReplaceCommand("#{$wrapper_id}", \Drupal::service('renderer')->render($form)));
-
-  return $response;
 }
 
 /**
@@ -320,14 +315,12 @@ function dhsc_result_viewer_save_edit_submit(&$form, FormStateInterface $form_st
 
     $token = $submission->get('token')->getValue();
 
-    $current_page = $form_state->get('current_page');
-    $all_pages = array_keys($submission->getWebform()->getPages());
-    $current_step = array_search($current_page, $all_pages) + 1;
+    $current_step = getCurrentStep($form_state);
 
     // Generate the redirect URL with webform ID and token.
     $webform_id = $submission->getWebform()->id();
     $redirect_url = Url::fromRoute(
-      'dhsc_result_viewer.themed_result_summary',
+      'dhsc_result_viewer.themed_response_summary',
       ['webform_id' => $webform_id, 'token' => $token[0]['value']],
       [
         'absolute' => TRUE,
@@ -338,6 +331,17 @@ function dhsc_result_viewer_save_edit_submit(&$form, FormStateInterface $form_st
     // Set redirect.
     $form_state->setRedirectUrl(Url::fromUri($redirect_url));
   }
+}
+
+/**
+ * Get current step
+ */
+function getCurrentStep(FormStateInterface $form_state): ?int {
+  $current_page = $form_state->get('current_page');
+  $submission = $form_state->getFormObject()->getEntity();
+  $all_pages = array_keys($submission->getWebform()->getPages());
+
+  return array_search($current_page, $all_pages) + 1;
 }
 
 /**
@@ -384,19 +388,69 @@ function dhsc_result_viewer_preprocess_status_messages(array &$variables) {
  * Implements hook_webform_submission_form_alter().
  */
 function dhsc_result_viewer_webform_submission_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
+  $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+
   // Target specific web forms.
-  if (in_array($form['#webform_id'], [
-      'self_assessment_tool',
-      'assured_solutions_tool',
-      'dsf_tool',
-      'dsf_tool_advanced',
-      'what_good_looks_like_tool',
-    ]) && ($current_page = $form_state->get('current_page') !== '')) {
-    // Add a hidden form element to track the current step.
-    $form['current_step'] = [
-      '#type' => 'value',
-      '#value' => $current_page,
-    ];
+  if (dhsc_result_viewer_get_webform_tool_service()->isToolSubmissionForm($form_id)) {
+    if ($current_page = $form_state->get('current_page') !== '') {
+      // Add a hidden form element to track the current step.
+      $form['current_step'] = [
+        '#type' => 'value',
+        '#value' => $current_page,
+      ];
+    }
+  }
+  if ($webform_tool_service->isThemedToolSubmissionForm($form_id)) {
+    $webform_id = $form['#webform_id'];
+    $submission_id = $webform_tool_service->getSubmissionId($webform_id);
+
+    // Auto-save progress on wizard step navigation.
+    if (isset($form['actions']['wizard_next'])) {
+      array_unshift($form['actions']['wizard_next']['#submit'], 'dhsc_result_viewer_store_draft_submission');
+    }
+
+    if (!$submission_id) {
+      // Create a draft submission.
+      $webform_tool_service->createDraftSubmission($webform_id);
+    }
+
+    // Store last completed step
+    $last_step = $webform_tool_service->getStepValue($webform_id) ?? 1;
+    $current_step = getCurrentStep($form_state);
+
+    if ($current_step > $last_step) {
+      $webform_tool_service->setStepValue($webform_id, $current_step);
+    }
+  }
+}
+
+/**
+ * Custom submit handler to store form data against the draft submission.
+ */
+function dhsc_result_viewer_store_draft_submission(array &$form, FormStateInterface $form_state) {
+  $webform_id = $form['#webform_id'];
+  $tempstore = \Drupal::service('tempstore.private')->get('dhsc_result_viewer');
+  $submission_id = $tempstore->get('last_submission_' . $webform_id);
+
+  if ($submission_id && ($submission = WebformSubmission::load($submission_id))) {
+    // Retrieve form data.
+    $data = $form_state->getValues();
+
+    // Update the submission data.
+    $submission->setData($data);
+    $submission->set('in_draft', TRUE); // Keep it as a draft.
+    $submission->save();
+
+    if (WebformToolConstants::DEBUG_MODE) {
+      \Drupal::messenger()->addMessage('Draft saved before proceeding.');
+    }
+  }
+  if (!$submission_id) {
+    if (WebformToolConstants::DEBUG_MODE) {
+      \Drupal::logger('dhsc_result_viewer')
+        ->warning('No submission ID found in tempstore for webform @webform_id.', ['@webform_id' => $webform_id]);
+    }
+    return;
   }
 }
 
@@ -404,10 +458,8 @@ function dhsc_result_viewer_webform_submission_form_alter(array &$form, FormStat
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function dhsc_result_viewer_theme_suggestions_webform_submission_form_alter(array &$suggestions, array $variables, $hook) {
-  if (in_array($variables['form']['#webform_id'], [
-    'self_assessment_tool',
-    'assured_solutions_tool',
-  ])) {
+  $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+  if ($webform_tool_service->isIndividualToolSubmissionForm($hook)) {
     $suggestions[] = 'webform_submission_form' . '__dhsc_tool__step';
     $suggestions[] = 'webform_submission_form' . '__dhsc_tool__' . $variables['form']['current_step']['#value'];
   }
@@ -454,14 +506,27 @@ function dhsc_result_viewer_theme_suggestions_dhsc_themed_results_pdf_content_al
 }
 
 /**
- * Implements hook_theme_suggestions_HOOK_alter() for dhsc_themed_results_list.
+ * Implements hook_theme_suggestions_HOOK_alter() for dhsc_themed_response_list.
  */
-function dhsc_result_viewer_theme_suggestions_dhsc_themed_results_list_alter(array &$suggestions, array $variables) {
+function dhsc_result_viewer_theme_suggestions_dhsc_themed_response_list_alter(array &$suggestions, array $variables) {
   if (!empty($variables['webform_id'])) {
     $webform_id = $variables['webform_id'];
 
     // Add a theme suggestion using the webform ID as a suffix.
-    $suggestions[] = 'dhsc_themed_results_list__' . $webform_id;
+    $suggestions[] = 'dhsc_themed_response_list__' . $webform_id;
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for
+ * dhsc_themed_recommendation_item.
+ */
+function dhsc_result_viewer_theme_suggestions_dhsc_themed_recommendation_item_alter(array &$suggestions, array $variables) {
+  if (!empty($variables['webform_id'])) {
+    $webform_id = $variables['webform_id'];
+
+    // Add a theme suggestion using the webform ID as a suffix.
+    $suggestions[] = 'dhsc_themed_recommendation_item__' . $webform_id;
   }
 }
 
@@ -547,4 +612,39 @@ function getLandingPagePath(string $webform_id): ?string {
     }
   }
   return NULL;
+}
+
+/**
+ * Implements hook_entity_presave().
+ */
+function dhsc_result_viewer_entity_presave(EntityInterface $entity) {
+  // Ensure this is a webform submission entity.
+  if ($entity instanceof WebformSubmissionInterface) {
+    $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+    $webform_id = $entity->getWebform()->id();
+    if ($webform_tool_service->isThemedTool($webform_id)) {
+      // Check if the submission was a draft but is now finalized.
+      if ($entity->isDraft() === FALSE) {
+        // Get the WebformToolService.
+        $webform_tool_service = dhsc_result_viewer_get_webform_tool_service();
+
+        // Clear tempstore values since the form has been fully submitted.
+        $webform_tool_service->clearSubmissionData($webform_id);
+      }
+    }
+  }
+}
+
+/**
+ * Provides a reusable way to fetch the WebformToolService.
+ *
+ * @return \Drupal\dhsc_result_viewer\Service\WebformToolService
+ *   The WebformToolService instance.
+ */
+function dhsc_result_viewer_get_webform_tool_service() {
+  static $service;
+  if (!$service) {
+    $service = \Drupal::service('dhsc_result_viewer.webform_tool_service');
+  }
+  return $service;
 }

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.module
@@ -10,7 +10,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\WebformSubmissionInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\dhsc_result_viewer\Constants\WebformToolConstants;
 
@@ -243,22 +242,6 @@ function dhsc_result_viewer_form_alter(array &$form, FormStateInterface $form_st
     }
   }
 }
-
-///**
-// * AJAX callback to auto-save submission data.
-// *
-// * @throws \Drupal\Core\Entity\EntityStorageException
-// */
-//function dhsc_result_viewer_save_submission_progress(array &$form, FormStateInterface $form_state) {
-//  $submission_id = $form_state->getValue('submission_id');
-//  if ($submission_id) {
-//    $data = $form_state->getValues();
-//    $submission = WebformSubmission::load($submission_id);
-//    $submission->setData($data);
-//    $submission->save();
-//  }
-//  return $form;
-//}
 
 /**
  * Submit handler for the Back button.

--- a/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.services.yml
+++ b/docroot/modules/custom/dhsc_result_viewer/dhsc_result_viewer.services.yml
@@ -1,4 +1,5 @@
 services:
+
   dhsc_self_assessment_result_viewer.service:
     class: Drupal\dhsc_result_viewer\SelfAssessmentResultViewer
     arguments: ['@entity_type.manager', '@config.factory', '@tempstore.private']
@@ -20,3 +21,13 @@ services:
   dhsc_result_viewer.dompdf_generator:
     class: \Drupal\dhsc_result_viewer\DhscDomPdfGenerator
     arguments: ['@renderer', '@request_stack', '@module_handler', '@extension.list.module', '@file_system']
+
+  dhsc_result_viewer.route_subscriber:
+    class: Drupal\dhsc_result_viewer\Routing\RouteSubscriber
+    arguments: ['@tempstore.private']
+    tags:
+      - { name: event_subscriber }
+
+  dhsc_result_viewer.webform_tool_service:
+    class: Drupal\dhsc_result_viewer\Service\WebformToolService
+    arguments: ['@tempstore.private', '@current_user', '@messenger', '@logger.factory', '@request_stack', '@form_builder', '@renderer', '@string_translation']

--- a/docroot/modules/custom/dhsc_result_viewer/src/Constants/WebformToolConstants.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Constants/WebformToolConstants.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\dhsc_result_viewer\Constants;
+
+/**
+ * Defines constants for webform tool identifiers.
+ */
+class WebformToolConstants {
+
+  /**
+   * Debug flag to control logging and on-screen messages.
+   */
+  public const DEBUG_MODE = FALSE;
+
+  /**
+   * Constants defining webform_id values for tools that this module extends.
+   */
+  public const SELF_ASSESSMENT_TOOL = 'self_assessment_tool';
+  public const ASSURED_SOLUTIONS_TOOL = 'assured_solutions_tool';
+  public const DSF_TOOL = 'dsf_tool';
+  public const DSF_TOOL_ADVANCED = 'dsf_tool_advanced';
+  public const WHAT_GOOD_LOOKS_LIKE_TOOL = 'what_good_looks_like_tool';
+
+  public const WEBFORM_TOOLS = [
+    self::SELF_ASSESSMENT_TOOL,
+    self::ASSURED_SOLUTIONS_TOOL,
+    self::DSF_TOOL,
+    self::DSF_TOOL_ADVANCED,
+    self::WHAT_GOOD_LOOKS_LIKE_TOOL,
+  ];
+
+  public const WEBFORM_TOOLS_INDIVIDUAL = [
+    self::SELF_ASSESSMENT_TOOL,
+    self::ASSURED_SOLUTIONS_TOOL,
+  ];
+
+  public const WEBFORM_TOOLS_THEMED = [
+    self::DSF_TOOL,
+    self::DSF_TOOL_ADVANCED,
+    self::WHAT_GOOD_LOOKS_LIKE_TOOL,
+  ];
+
+}

--- a/docroot/modules/custom/dhsc_result_viewer/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Routing/RouteSubscriber.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\dhsc_result_viewer\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\dhsc_result_viewer\Constants\WebformToolConstants;
+
+/**
+ * Handles redirection logic for webform submissions.
+ */
+class RouteSubscriber extends RouteSubscriberBase implements EventSubscriberInterface {
+
+  /**
+   * The private temp store factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected PrivateTempStoreFactory $tempStoreFactory;
+
+  /**
+   * Constructs a new RouteSubscriber.
+   *
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The private temp store factory.
+   */
+  public function __construct(PrivateTempStoreFactory $temp_store_factory) {
+    $this->tempStoreFactory = $temp_store_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection): void {
+    // No need to modify _controller, just handle redirection dynamically.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      // Priority 30 ensures it runs early.
+      KernelEvents::REQUEST => ['checkForRedirection', 30],
+    ];
+  }
+
+  /**
+   * Checks if the user should be redirected to their latest webform submission.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The request event.
+   */
+  public function checkForRedirection(RequestEvent $event): void {
+    $request = $event->getRequest();
+
+    $webform = $request->attributes->get('webform');
+    if (!$webform) {
+      return;
+    }
+
+    $webform_id = $webform->id();
+
+    if (in_array($webform_id, WebformToolConstants::WEBFORM_TOOLS_THEMED, TRUE)) {
+      $route_name = $request->attributes->get('_route');
+
+      // Only apply redirection for the webform page.
+      if ($route_name !== 'entity.webform.canonical') {
+        return;
+      }
+
+      // Prevent redirect loop by checking if the token is already present.
+      if ($request->query->has('token')) {
+        return;
+      }
+
+      // Retrieve the last submission and step from private tempstore.
+      $tempstore = $this->tempStoreFactory->get('dhsc_result_viewer');
+      $submission_id = $tempstore->get('last_submission_' . $webform_id);
+
+      if ($submission_id && ($submission = WebformSubmission::load($submission_id))) {
+        $token = $submission->getToken();
+
+        // Build the redirect URL.
+        $redirect_url = '/form/' . str_replace('_', '-', $webform_id) . '?token=' . $token;
+        $response = new RedirectResponse($redirect_url);
+        $event->setResponse($response);
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/dhsc_result_viewer/src/Service/WebformToolService.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Service/WebformToolService.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Drupal\dhsc_result_viewer\Service;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Form\FormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Url;
+use Drupal\webform\Entity\WebformSubmission;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\dhsc_result_viewer\Constants\WebformToolConstants;
+
+/**
+ * Provides a service for managing Webform result submissions.
+ */
+class WebformToolService {
+
+  use StringTranslationTrait;
+
+  /**
+   * The private temp store factory.
+   */
+  protected PrivateTempStoreFactory $tempStoreFactory;
+
+  /**
+   * The current user.
+   */
+  protected AccountProxyInterface $currentUser;
+
+  /**
+   * The messenger service.
+   */
+  protected MessengerInterface $messenger;
+
+  /**
+   * The logger factory.
+   */
+  protected LoggerChannelFactoryInterface $loggerFactory;
+
+  /**
+   * The request stack service.
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * The form builder service.
+   */
+  protected FormBuilderInterface $formBuilder;
+
+  /**
+   * The renderer service.
+   */
+  protected RendererInterface $renderer;
+
+  /**
+   * Translation service.
+   *
+   * @var \Drupal\Core\StringTranslation\TranslationInterface
+   */
+  protected $stringTranslation;
+
+  /**
+   * Constructs the WebformToolService.
+   */
+  public function __construct(
+    PrivateTempStoreFactory $temp_store_factory,
+    AccountProxyInterface $current_user,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $loggerFactory,
+    RequestStack $request_stack,
+    FormBuilderInterface $formBuilder,
+    RendererInterface $renderer,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->currentUser = $current_user;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $loggerFactory;
+    $this->requestStack = $request_stack;
+    $this->formBuilder = $formBuilder;
+    $this->renderer = $renderer;
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Retrieves the last submission ID for a given webform.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   *
+   * @return int|null
+   *   The SID
+   */
+  public function getSubmissionId(string $webform_id): ?int {
+    $submission_id = $this->tempStoreFactory->get('dhsc_result_viewer')
+      ->get('last_submission_' . $webform_id);
+    $this->logMessage('Retrieved submission ID', $submission_id, $webform_id);
+    return $submission_id;
+  }
+
+  /**
+   * Saves a submission ID in the temp store.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   * @param int $submission_id
+   *   The submission ID we're storing.
+   *
+   * @throws \Drupal\Core\TempStore\TempStoreException
+   */
+  public function setSubmissionId(string $webform_id, int $submission_id): void {
+    $this->tempStoreFactory->get('dhsc_result_viewer')
+      ->set('last_submission_' . $webform_id, $submission_id);
+    $this->logMessage('Saved submission ID', $submission_id, $webform_id);
+  }
+
+  /**
+   * Retrieves the last step value for a given webform.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   *
+   * @return int|null
+   *   The step value.
+   */
+  public function getStepValue(string $webform_id): ?int {
+    $step_value = $this->tempStoreFactory->get('dhsc_result_viewer')
+      ->get('last_step_' . $webform_id);
+    $this->logMessage('Retrieved step value', $step_value, $webform_id);
+    return $step_value;
+  }
+
+  /**
+   * Saves a step value in the temp store.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   * @param int $current_step
+   *   The step value we're storing.
+   *
+   * @throws \Drupal\Core\TempStore\TempStoreException
+   */
+  public function setStepValue(string $webform_id, int $current_step): void {
+    $this->tempStoreFactory->get('dhsc_result_viewer')
+      ->set('last_step_' . $webform_id, $current_step);
+    $this->logMessage('Saved step value', $current_step, $webform_id);
+  }
+
+  /**
+   * Creates a draft Webform submission.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   *
+   * @return \Drupal\webform\Entity\WebformSubmission|null
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\Core\TempStore\TempStoreException
+   */
+  public function createDraftSubmission(string $webform_id): ?WebformSubmission {
+    $submission = WebformSubmission::create([
+      'webform_id' => $webform_id,
+      'uid' => $this->currentUser->id(),
+      'is_draft' => TRUE,
+      'data' => [],
+    ]);
+    $submission->save();
+
+    $this->setSubmissionId($webform_id, $submission->id());
+    return $submission;
+  }
+
+  /**
+   * Get the requested step from the current request.
+   */
+  public function getRequestedStep(): ?int {
+    $request = $this->requestStack->getCurrentRequest();
+    return (int) $request->query->get('edit-page');
+  }
+
+  /**
+   * Generate the summary URL for re-edit mode.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   * @param string $token
+   *   Submission token string.
+   * @param int $requested_step
+   *   The step we're returning to.
+   *
+   * @return string
+   *   The URL as a string.
+   */
+  public function getSummaryUrl(string $webform_id, string $token, int $requested_step): string {
+    return Url::fromRoute(
+      'dhsc_result_viewer.themed_response_summary',
+      ['webform_id' => $webform_id, 'token' => $token],
+      ['absolute' => TRUE, 'fragment' => 'response-' . $requested_step]
+    )->toString();
+  }
+
+  /**
+   * Get the previous step in the wizard.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
+   *
+   * @return string|null
+   *   Return previous step as a string.
+   */
+  public function getPreviousStep(FormStateInterface $form_state): ?string {
+    $current_page = $form_state->get('current_page');
+    $all_pages = $form_state->get('pages');
+    $current_step = array_search($current_page, array_keys($all_pages), TRUE) + 1;
+    return ($current_step > 1) ? array_keys($all_pages)[$current_step - 2] : NULL;
+  }
+
+  /**
+   * Get the landing page URL or fallback to front page.
+   */
+  public function getLandingPageUrl(): string {
+    return Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
+  }
+
+  /**
+   * Perform a redirect response.
+   *
+   * @param string $url
+   *   The URL to redirect to.
+   */
+  public function performRedirect(string $url) {
+    $response = new RedirectResponse($url);
+    $response->send();
+    exit();
+  }
+
+  /**
+   * Rebuild the webform via AJAX.
+   *
+   * @param array $form
+   *   Form array provided via a form submit callback.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   Returns an AjaxResponse.
+   *
+   * @throws \Exception
+   */
+  public function rebuildWebformAjax(array &$form, FormStateInterface $form_state): AjaxResponse {
+    $response = new AjaxResponse();
+    $form = $this->formBuilder->rebuildForm($form_state->getBuildInfo()['form_id'], $form_state);
+    $wrapper_id = $form['#id'] ?? 'webform-ajax-wrapper';
+    $response->addCommand(new ReplaceCommand("#{$wrapper_id}", $this->renderer->render($form)));
+    return $response;
+  }
+
+  /**
+   * Logs and displays messages.
+   *
+   * @param string $message
+   *   THe message to log.
+   * @param mixed $value
+   *   The value to report.
+   * @param string $webform_id
+   *   The webform_id our message is referring to.
+   */
+  private function logMessage(string $message, mixed $value, string $webform_id): void {
+    if (WebformToolConstants::DEBUG_MODE) {
+      $this->messenger->addStatus($this->t("@message: @value for webform: @webform", [
+        '@message' => $message,
+        '@value' => $value,
+        '@webform' => $webform_id,
+      ]));
+
+      $this->loggerFactory->get('dhsc_result_viewer')
+        ->info("$message: @value for webform: @webform", [
+          '@value' => $value,
+          '@webform' => $webform_id,
+        ]);
+    }
+  }
+
+  /**
+   * Checks if the form ID belongs to a tool submission form.
+   *
+   * @param string $form_id
+   *   Form ID that is being tested.
+   *
+   * @return bool
+   *   Truth of statement.
+   */
+  public function isToolSubmissionForm(string $form_id): bool {
+    return str_starts_with($form_id, 'webform_submission') &&
+      !empty(array_filter(WebformToolConstants::WEBFORM_TOOLS, fn($word) => str_contains($form_id, $word)));
+  }
+
+  /**
+   * Checks if the form ID belongs to a themed tool submission form.
+   *
+   * @param string $form_id
+   *   Form ID that is being tested.
+   *
+   * @return bool
+   *   Truth of statement.
+   */
+  public function isThemedToolSubmissionForm(string $form_id): bool {
+    return str_starts_with($form_id, 'webform_submission') &&
+      !empty(array_filter(WebformToolConstants::WEBFORM_TOOLS_THEMED, fn($word) => str_contains($form_id, $word)));
+  }
+
+  /**
+   * Checks if the form ID belongs to an individual tool submission form.
+   *
+   * @param string $form_id
+   *   Form ID that is being tested.
+   *
+   * @return bool
+   *   Truth of statement.
+   */
+  public function isIndividualToolSubmissionForm(string $form_id): bool {
+    return str_starts_with($form_id, 'webform_submission') &&
+      !empty(array_filter(WebformToolConstants::WEBFORM_TOOLS_INDIVIDUAL, fn($word) => str_contains($form_id, $word)));
+  }
+
+  /**
+   * Checks if the webform ID is in the themed tools list.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   *
+   * @return bool
+   *   Truth of statement.
+   */
+  public function isThemedTool(string $webform_id): bool {
+    return in_array($webform_id, WebformToolConstants::WEBFORM_TOOLS_THEMED, TRUE);
+  }
+
+  /**
+   * Clears the tempstore values for a webform after successful submission.
+   *
+   * @param string $webform_id
+   *   The webform ID.
+   */
+  public function clearSubmissionData(string $webform_id): void {
+    $tempstore = $this->tempStoreFactory->get('dhsc_result_viewer');
+    $tempstore->delete('last_submission_' . $webform_id);
+    $tempstore->delete('last_step_' . $webform_id);
+
+    $this->logMessage('Cleared tempstore data', 'N/A', $webform_id);
+  }
+
+}


### PR DESCRIPTION
- feature: (DHSCMS04-74) Refactored webform tool handling and improved themed tool support. Centralised service fetching, optimised wizard navigation, and enhanced draft submission tracking.
   - Introduced `dhsc_result_viewer_get_webform_tool_service()` helper function to centralise service fetching.
   - Replaced direct calls to `\Drupal::service()` with the cached service instance.
   - Refactored `hook_form_alter()` to use `isToolSubmissionForm()` and `isThemedToolSubmissionForm()` for cleaner logic.
   - Improved handling of wizard navigation by introducing `getRequestedStep()`, `getPreviousStep()`, and `getLandingPageUrl()` inside the service.
   - Refactored form submission processing:
     - Added `dhsc_result_viewer_store_draft_submission()` to handle draft submissions more efficiently.
     - Implemented automatic progress saving on wizard navigation.
     - Improved tracking of the last completed steps.
   - Updated `hook_theme_suggestions_HOOK_alter()` implementations:
     - Introduced `dhsc_result_viewer_theme_suggestions_dhsc_themed_response_list_alter()`.
     - Introduced `dhsc_result_viewer_theme_suggestions_dhsc_themed_recommendation_item_alter()`.
   - Replaced old "results" terminology with "response" for consistency (`dhsc_themed_results_list` → `dhsc_themed_response_list`).
   - Added `hook_entity_presave()` to clear tempstore values upon finalised submission.
   - Improved logging and debugging with `WebformToolConstants::DEBUG_MODE`.
- feature: (DHSCMS04-74) Provide constants via a class to help provide a central place to reference tools. Add a debug mode to allow a developer to understand what is happening more easily.
- feature: (DHSCMS04-74) Provide a route subscriber to allow refresh events to be augmented with a submission token, when a submission is partially completed.
- feature: (DHSCMS04-74) Webform requires interaction via hooks at times. This was creating a lot of unstructured procedural code in *.module. To counter this we now use a custom service to provide helper functions.
- feature: (DHSCMS04-74) Remove commented code. Remove unused class reference.
- feature: (DHSCMS04-74) Update services to ensure we can use new custom service.