### PR TITLE
bugfix: (DHSCMS04-82) We already have the webform ID, so this does no…

### DIFF
--- a/docroot/modules/custom/dhsc_result_viewer/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/dhsc_result_viewer/src/Routing/RouteSubscriber.php
@@ -60,12 +60,10 @@ class RouteSubscriber extends RouteSubscriberBase implements EventSubscriberInte
   public function checkForRedirection(RequestEvent $event): void {
     $request = $event->getRequest();
 
-    $webform = $request->attributes->get('webform');
-    if (!$webform) {
+    $webform_id = $request->attributes->get('webform');
+    if (!$webform_id) {
       return;
     }
-
-    $webform_id = $webform->id();
 
     if (in_array($webform_id, WebformToolConstants::WEBFORM_TOOLS_THEMED, TRUE)) {
       $route_name = $request->attributes->get('_route');


### PR DESCRIPTION
- bugfix: (DHSCMS04-82) We already have the webform ID, so this does not need to be obtained via a method call. Rename variable to reflect this.