### PR TITLE
Feature/ms02 dhsc 2 add file format and size to download links

### DIFF
--- a/config/default/sync/core.entity_form_display.media.document.default.yml
+++ b/config/default/sync/core.entity_form_display.media.document.default.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.document.field_file_size
     - field.field.media.document.field_media_document
+    - field.field.media.document.field_mime_types
+    - field.field.media.document.field_plain_language_name
     - media.type.document
   module:
     - file
@@ -17,9 +20,16 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 4
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_file_size:
+    type: number
+    weight: 6
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_media_document:
     type: file_generic
@@ -28,29 +38,45 @@ content:
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
+  field_mime_types:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_plain_language_name:
+    type: string_textfield
+    weight: 8
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 1
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 4
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 100
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/default/sync/core.entity_view_display.media.document.default.yml
+++ b/config/default/sync/core.entity_view_display.media.document.default.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.document.field_file_size
     - field.field.media.document.field_media_document
+    - field.field.media.document.field_mime_types
+    - field.field.media.document.field_plain_language_name
     - media.type.document
   module:
     - file
@@ -14,12 +17,37 @@ targetEntityType: media
 bundle: document
 mode: default
 content:
+  field_file_size:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_media_document:
     type: file_default
     label: visually_hidden
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_mime_types:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_plain_language_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
     region: content
 hidden:
   created: true

--- a/config/default/sync/core.entity_view_display.media.document.document_link_with_type_filesize.yml
+++ b/config/default/sync/core.entity_view_display.media.document.document_link_with_type_filesize.yml
@@ -1,0 +1,37 @@
+uuid: 5cf46f0d-12c2-4ec5-a0de-cdd619d21e8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.document_link_with_type_filesize
+    - field.field.media.document.field_file_size
+    - field.field.media.document.field_media_document
+    - field.field.media.document.field_mime_types
+    - field.field.media.document.field_plain_language_name
+    - media.type.document
+  module:
+    - dhsc_site
+_core:
+  default_config_hash: PKsZLhRLrXFHjGpwQ2mnGGYIxX2AhT875Z7eoAwDRfM
+id: media.document.document_link_with_type_filesize
+targetEntityType: media
+bundle: document
+mode: document_link_with_type_filesize
+content:
+  field_media_document:
+    type: document_link_formatter
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_file_size: true
+  field_mime_types: true
+  field_plain_language_name: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/default/sync/core.entity_view_mode.media.document_link_with_type_filesize.yml
+++ b/config/default/sync/core.entity_view_mode.media.document_link_with_type_filesize.yml
@@ -1,0 +1,11 @@
+uuid: d8c5be87-db60-478d-a5f7-ad4a47d61e3d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.document_link_with_type_filesize
+label: 'Document Link (with type / filesize)'
+description: ''
+targetEntityType: media
+cache: true

--- a/config/default/sync/editor.editor.basic_html.yml
+++ b/config/default/sync/editor.editor.basic_html.yml
@@ -29,6 +29,7 @@ settings:
       - '|'
       - blockQuote
       - drupalInsertImage
+      - drupalMedia
       - '|'
       - sourceEditing
       - '|'
@@ -81,5 +82,7 @@ settings:
     linkit_extension:
       linkit_enabled: true
       linkit_profile: default
+    media_media:
+      allow_view_mode_override: false
 image_upload:
   status: false

--- a/config/default/sync/editor.editor.full_html.yml
+++ b/config/default/sync/editor.editor.full_html.yml
@@ -30,6 +30,7 @@ settings:
       - '|'
       - blockQuote
       - drupalInsertImage
+      - drupalMedia
       - '|'
       - sourceEditing
       - insertTable
@@ -111,5 +112,7 @@ settings:
     linkit_extension:
       linkit_enabled: true
       linkit_profile: default
+    media_media:
+      allow_view_mode_override: false
 image_upload:
   status: false

--- a/config/default/sync/field.field.media.document.field_file_size.yml
+++ b/config/default/sync/field.field.media.document.field_file_size.yml
@@ -1,0 +1,23 @@
+uuid: 97e192b1-3aa3-4b43-936d-a06c72dcab1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_file_size
+    - media.type.document
+id: media.document.field_file_size
+field_name: field_file_size
+entity_type: media
+bundle: document
+label: 'File size'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/default/sync/field.field.media.document.field_mime_types.yml
+++ b/config/default/sync/field.field.media.document.field_mime_types.yml
@@ -1,0 +1,19 @@
+uuid: 8c0e52a0-9fb3-4f96-996b-5a5bd3b15b26
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_mime_types
+    - media.type.document
+id: media.document.field_mime_types
+field_name: field_mime_types
+entity_type: media
+bundle: document
+label: 'Mime types'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/sync/field.field.media.document.field_plain_language_name.yml
+++ b/config/default/sync/field.field.media.document.field_plain_language_name.yml
@@ -1,0 +1,19 @@
+uuid: df000987-0002-4c0f-b1ad-3a4f736477b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_plain_language_name
+    - media.type.document
+id: media.document.field_plain_language_name
+field_name: field_plain_language_name
+entity_type: media
+bundle: document
+label: 'Plain language name'
+description: 'Add a simple name describing the content of this document. This will be displayed when the document is embedded using the content editor.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/sync/field.storage.media.field_file_size.yml
+++ b/config/default/sync/field.storage.media.field_file_size.yml
@@ -1,0 +1,20 @@
+uuid: 9e28849c-b1d6-41f9-b64a-e53e2f74747d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_file_size
+field_name: field_file_size
+entity_type: media
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/sync/field.storage.media.field_mime_types.yml
+++ b/config/default/sync/field.storage.media.field_mime_types.yml
@@ -1,0 +1,21 @@
+uuid: 9326ca7a-fba6-41f8-94bd-e9e67166b940
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_mime_types
+field_name: field_mime_types
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/sync/field.storage.media.field_plain_language_name.yml
+++ b/config/default/sync/field.storage.media.field_plain_language_name.yml
@@ -1,0 +1,21 @@
+uuid: dc6b6297-e7fe-4f71-a1a7-fad518a35d61
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_plain_language_name
+field_name: field_plain_language_name
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/sync/media.type.document.yml
+++ b/config/default/sync/media.type.document.yml
@@ -1,7 +1,26 @@
 uuid: bb024cb1-d665-479f-85bf-f2aa446fe34d
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+    - scheduler
+third_party_settings:
+  crop:
+    image_field: _none
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 _core:
   default_config_hash: _D9q3XSnP6ik9we9UuoTvZsQKPuYNp_G9PfwVtWzgnQ
 id: document
@@ -13,4 +32,6 @@ new_revision: true
 source_configuration:
   source_field: field_media_document
 field_map:
-  name: name
+  name: field_plain_language_name
+  mimetype: field_mime_types
+  filesize: field_file_size

--- a/docroot/modules/custom/dhsc_site/src/Plugin/Field/FieldFormatter/DocumentLinkFormatter.php
+++ b/docroot/modules/custom/dhsc_site/src/Plugin/Field/FieldFormatter/DocumentLinkFormatter.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\dhsc_site\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\file\FileInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Plugin implementation of the 'document_link_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "document_link_formatter",
+ *   label = @Translation("Document Link with Metadata"),
+ *   field_types = {
+ *     "file"
+ *   }
+ * )
+ */
+class DocumentLinkFormatter extends FormatterBase {
+
+  /**
+   * The file URL generator service.
+   *
+   * @var \Drupal\Core\File\FileUrlGeneratorInterface
+   */
+  protected $fileUrlGenerator;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a DocumentLinkFormatter object.
+   */
+  public function __construct(string $plugin_id, mixed $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, string $label, string $view_mode, array $third_party_settings, FileUrlGeneratorInterface $file_url_generator, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->fileUrlGenerator = $file_url_generator;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('file_url_generator'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $file = $item->entity;
+
+      if (!$file instanceof FileInterface) {
+        continue;
+      }
+
+      $file_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+
+      $media = $this->loadParentEntity($file, 'media', $items->getName());
+      $plain_name = $media->get('field_plain_language_name')->value;
+      $raw_size = $media->get('field_file_size')->value;
+      $file_size = ByteSizeMarkup::create((int) $raw_size);
+      $mime_type = $media->get('field_mime_types')->value;
+      $file_type = $this->getMimeTypeLabels($mime_type);
+      $link_text = $plain_name ?: $media->label();
+
+      $metadata = sprintf('%s %s', $file_type, $file_size);
+
+      $link = Link::fromTextAndUrl($link_text, Url::fromUri($file_url))
+        ->toRenderable();
+      $link['#suffix'] = Markup::create(' <span>' . $metadata . '</span>');
+
+      $elements[$delta] = $link;
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Load the parent entity that references a given entity via a specific field.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The referenced entity.
+   * @param string $parent_entity_type
+   *   The entity type to search (e.g. 'node', 'media').
+   * @param string $field_name
+   *   The field name on the parent entity that references the child.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The first parent entity found, or NULL.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  public function loadParentEntity($entity, $parent_entity_type, $field_name) {
+    $storage = $this->entityTypeManager->getStorage($parent_entity_type);
+    $ids = $storage->getQuery()
+      ->condition($field_name . '.target_id', $entity->id())
+      ->accessCheck(TRUE)
+      ->range(0, 1)
+      ->execute();
+
+    return $ids ? $storage->load(reset($ids)) : NULL;
+  }
+
+  /**
+   * Returns a human-readable label for a given MIME type.
+   *
+   * @param string $mime_type
+   *   The MIME type (e.g., 'application/pdf').
+   *
+   * @return string
+   *   The human-readable label (e.g., 'PDF document').
+   */
+  public function getMimeTypeLabels($mime_type) {
+    $mime_labels = [
+      // Documents.
+      'application/pdf' => 'PDF document',
+      'application/msword' => 'Word document',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'Word document (DOCX)',
+      'application/vnd.ms-excel' => 'Excel spreadsheet',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'Excel spreadsheet (XLSX)',
+      'application/vnd.ms-powerpoint' => 'PowerPoint presentation',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'PowerPoint presentation (PPTX)',
+      'application/rtf' => 'Rich Text Format document',
+      'text/plain' => 'Plain text file',
+
+      // Images.
+      'image/jpeg' => 'JPEG image',
+      'image/png' => 'PNG image',
+      'image/gif' => 'GIF image',
+      'image/webp' => 'WebP image',
+      'image/svg+xml' => 'SVG vector image',
+      'image/tiff' => 'TIFF image',
+
+      // Archives & compressed.
+      'application/zip' => 'ZIP archive',
+      'application/x-tar' => 'TAR archive',
+      'application/x-gzip' => 'GZIP archive',
+      'application/x-bzip2' => 'BZIP2 archive',
+      'application/x-7z-compressed' => '7-Zip archive',
+
+      // Audio & video (optional).
+      'audio/mpeg' => 'MP3 audio',
+      'audio/ogg' => 'Ogg audio',
+      'video/mp4' => 'MP4 video',
+      'video/x-msvideo' => 'AVI video',
+    ];
+
+    return $mime_labels[$mime_type] ?? $mime_type;
+  }
+
+}

--- a/docroot/themes/custom/dhsc_theme/templates/content/media--document--document-link-with-type-filesize.html.twig
+++ b/docroot/themes/custom/dhsc_theme/templates/content/media--document--document-link-with-type-filesize.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Theme override to present a media item.
+ *
+ * Available variables:
+ * - media: The media item, with limited access to object properties and
+ *   methods. Only method names starting with "get", "has", or "is" and
+ *   a few common methods such as "id", "label", and "bundle" are available.
+ *   For example:
+ *   - entity.getEntityTypeId() will return the entity type ID.
+ *   - entity.hasField('field_example') returns TRUE if the entity includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   Calling other methods, such as entity.delete(), will result in
+ *   an exception.
+ *   See \Drupal\Core\Entity\EntityInterface for a full list of methods.
+ * - name: Name of the media item.
+ * - content: Media content.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - attributes: HTML attributes for the containing element.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ *
+ * @see template_preprocess_media()
+ */
+#}
+{{ content }}
+


### PR DESCRIPTION
- feature: (MS02DHSC-2) Update text input formats to include media embed for documents.
- feature: (MS02DHSC-2) Update media entity to provide extra fields for mime type and filesize and include a new view_mode to provide metadata.
- feature: (MS02DHSC-2) Ensure base media fields are populated.
- feature: (MS02DHSC-2) Template for new view mode.
- feature: (MS02DHSC-2) Add custom file formatter to render document links with metadata.